### PR TITLE
feat: app startup initializer with one-time room seeding

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -42,9 +42,13 @@ include(
     ":shared:core-presentation",
     ":shared:core-navigation",
     ":shared:core-database",
+    ":shared:core-initializer",
     ":shared:common-ui",
 
     // Features
+    ":shared:feature-splash:presentation",
+    ":shared:feature-splash:ui",
+
     ":shared:feature-rooms:api",
     ":shared:feature-rooms:impl",
     ":shared:feature-rooms:presentation",

--- a/shared/common-resources/src/androidMain/kotlin/dev/nonoxy/residetrack/common/resources/AndroidFileResourceReader.kt
+++ b/shared/common-resources/src/androidMain/kotlin/dev/nonoxy/residetrack/common/resources/AndroidFileResourceReader.kt
@@ -1,0 +1,16 @@
+package dev.nonoxy.residetrack.common.resources
+
+import android.content.Context
+import dev.icerock.moko.resources.FileResource
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+internal class AndroidFileResourceReader(
+    private val context: Context,
+) : FileResourceReader {
+
+    override suspend fun readText(resource: FileResource): String =
+        withContext(Dispatchers.IO) {
+            resource.readText(context)
+        }
+}

--- a/shared/common-resources/src/androidMain/kotlin/dev/nonoxy/residetrack/common/resources/di/CommonResourcesModule.android.kt
+++ b/shared/common-resources/src/androidMain/kotlin/dev/nonoxy/residetrack/common/resources/di/CommonResourcesModule.android.kt
@@ -1,6 +1,8 @@
 package dev.nonoxy.residetrack.common.resources.di
 
+import dev.nonoxy.residetrack.common.resources.AndroidFileResourceReader
 import dev.nonoxy.residetrack.common.resources.AndroidStringConverter
+import dev.nonoxy.residetrack.common.resources.FileResourceReader
 import dev.nonoxy.residetrack.common.resources.StringConverter
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.new
@@ -9,4 +11,6 @@ import org.koin.dsl.module
 internal actual val platformResourcesModule: Module = module {
 
     factory<StringConverter> { new(::AndroidStringConverter) }
+
+    factory<FileResourceReader> { new(::AndroidFileResourceReader) }
 }

--- a/shared/common-resources/src/commonMain/kotlin/dev/nonoxy/residetrack/common/resources/FileResourceReader.kt
+++ b/shared/common-resources/src/commonMain/kotlin/dev/nonoxy/residetrack/common/resources/FileResourceReader.kt
@@ -1,0 +1,15 @@
+package dev.nonoxy.residetrack.common.resources
+
+import dev.icerock.moko.resources.FileResource
+
+/**
+ * Reads the text content of a moko [FileResource] from common code.
+ *
+ * moko exposes platform-specific read APIs (Android needs a `Context`, Apple reads from the bundle),
+ * so this interface hides the difference behind a single suspend call. Implementations dispatch the
+ * blocking read off the main thread.
+ */
+interface FileResourceReader {
+
+    suspend fun readText(resource: FileResource): String
+}

--- a/shared/common-resources/src/commonMain/moko-resources/files/rooms_seed.json
+++ b/shared/common-resources/src/commonMain/moko-resources/files/rooms_seed.json
@@ -1,0 +1,627 @@
+[
+  {
+    "floor": 3,
+    "number": 329,
+    "beds": 5
+  },
+  {
+    "floor": 3,
+    "number": 333,
+    "beds": 6
+  },
+  {
+    "floor": 3,
+    "number": 338,
+    "beds": 5
+  },
+  {
+    "floor": 3,
+    "number": 342,
+    "beds": 6
+  },
+  {
+    "floor": 3,
+    "number": 347,
+    "beds": 5
+  },
+  {
+    "floor": 3,
+    "number": 351,
+    "beds": 6
+  },
+  {
+    "floor": 3,
+    "number": 356,
+    "beds": 5
+  },
+  {
+    "floor": 3,
+    "number": 360,
+    "beds": 6
+  },
+  {
+    "floor": 3,
+    "number": 365,
+    "beds": 5
+  },
+  {
+    "floor": 3,
+    "number": 369,
+    "beds": 6
+  },
+  {
+    "floor": 3,
+    "number": 374,
+    "beds": 5
+  },
+  {
+    "floor": 3,
+    "number": 388,
+    "beds": 5
+  },
+  {
+    "floor": 3,
+    "number": 393,
+    "beds": 5
+  },
+  {
+    "floor": 3,
+    "number": 396,
+    "beds": 5
+  },
+  {
+    "floor": 4,
+    "number": 402,
+    "beds": 5
+  },
+  {
+    "floor": 4,
+    "number": 407,
+    "beds": 5
+  },
+  {
+    "floor": 4,
+    "number": 420,
+    "beds": 5
+  },
+  {
+    "floor": 4,
+    "number": 429,
+    "beds": 5
+  },
+  {
+    "floor": 4,
+    "number": 433,
+    "beds": 6
+  },
+  {
+    "floor": 4,
+    "number": 438,
+    "beds": 5
+  },
+  {
+    "floor": 4,
+    "number": 442,
+    "beds": 6
+  },
+  {
+    "floor": 4,
+    "number": 447,
+    "beds": 5
+  },
+  {
+    "floor": 4,
+    "number": 451,
+    "beds": 6
+  },
+  {
+    "floor": 4,
+    "number": 456,
+    "beds": 5
+  },
+  {
+    "floor": 4,
+    "number": 460,
+    "beds": 6
+  },
+  {
+    "floor": 4,
+    "number": 465,
+    "beds": 5
+  },
+  {
+    "floor": 4,
+    "number": 469,
+    "beds": 6
+  },
+  {
+    "floor": 4,
+    "number": 474,
+    "beds": 5
+  },
+  {
+    "floor": 4,
+    "number": 488,
+    "beds": 5
+  },
+  {
+    "floor": 4,
+    "number": 493,
+    "beds": 5
+  },
+  {
+    "floor": 4,
+    "number": 496,
+    "beds": 5
+  },
+  {
+    "floor": 3,
+    "number": 3002,
+    "beds": 5
+  },
+  {
+    "floor": 3,
+    "number": 3007,
+    "beds": 5
+  },
+  {
+    "floor": 4,
+    "number": 4002,
+    "beds": 5
+  },
+  {
+    "floor": 4,
+    "number": 4007,
+    "beds": 5
+  },
+  {
+    "floor": 5,
+    "number": 5003,
+    "beds": 5
+  },
+  {
+    "floor": 5,
+    "number": 5007,
+    "beds": 5
+  },
+  {
+    "floor": 5,
+    "number": 5019,
+    "beds": 5
+  },
+  {
+    "floor": 5,
+    "number": 5024,
+    "beds": 5
+  },
+  {
+    "floor": 5,
+    "number": 5033,
+    "beds": 4
+  },
+  {
+    "floor": 5,
+    "number": 5037,
+    "beds": 6
+  },
+  {
+    "floor": 5,
+    "number": 5042,
+    "beds": 4
+  },
+  {
+    "floor": 5,
+    "number": 5046,
+    "beds": 6
+  },
+  {
+    "floor": 5,
+    "number": 5051,
+    "beds": 5
+  },
+  {
+    "floor": 5,
+    "number": 5056,
+    "beds": 6
+  },
+  {
+    "floor": 5,
+    "number": 5061,
+    "beds": 5
+  },
+  {
+    "floor": 5,
+    "number": 5065,
+    "beds": 6
+  },
+  {
+    "floor": 5,
+    "number": 5071,
+    "beds": 5
+  },
+  {
+    "floor": 5,
+    "number": 5074,
+    "beds": 6
+  },
+  {
+    "floor": 5,
+    "number": 5079,
+    "beds": 5
+  },
+  {
+    "floor": 5,
+    "number": 5084,
+    "beds": 3
+  },
+  {
+    "floor": 5,
+    "number": 5096,
+    "beds": 5
+  },
+  {
+    "floor": 5,
+    "number": 5101,
+    "beds": 5
+  },
+  {
+    "floor": 5,
+    "number": 5107,
+    "beds": 5
+  },
+  {
+    "floor": 5,
+    "number": 5113,
+    "beds": 5
+  },
+  {
+    "floor": 5,
+    "number": 5117,
+    "beds": 5
+  },
+  {
+    "floor": 6,
+    "number": 6003,
+    "beds": 5
+  },
+  {
+    "floor": 6,
+    "number": 6007,
+    "beds": 5
+  },
+  {
+    "floor": 6,
+    "number": 6013,
+    "beds": 5
+  },
+  {
+    "floor": 6,
+    "number": 6019,
+    "beds": 5
+  },
+  {
+    "floor": 6,
+    "number": 6024,
+    "beds": 5
+  },
+  {
+    "floor": 6,
+    "number": 6033,
+    "beds": 5
+  },
+  {
+    "floor": 6,
+    "number": 6037,
+    "beds": 6
+  },
+  {
+    "floor": 6,
+    "number": 6042,
+    "beds": 5
+  },
+  {
+    "floor": 6,
+    "number": 6046,
+    "beds": 6
+  },
+  {
+    "floor": 6,
+    "number": 6051,
+    "beds": 5
+  },
+  {
+    "floor": 6,
+    "number": 6056,
+    "beds": 6
+  },
+  {
+    "floor": 6,
+    "number": 6061,
+    "beds": 5
+  },
+  {
+    "floor": 6,
+    "number": 6065,
+    "beds": 6
+  },
+  {
+    "floor": 6,
+    "number": 6071,
+    "beds": 5
+  },
+  {
+    "floor": 6,
+    "number": 6074,
+    "beds": 6
+  },
+  {
+    "floor": 6,
+    "number": 6079,
+    "beds": 5
+  },
+  {
+    "floor": 6,
+    "number": 6084,
+    "beds": 6
+  },
+  {
+    "floor": 6,
+    "number": 6089,
+    "beds": 6
+  },
+  {
+    "floor": 6,
+    "number": 6096,
+    "beds": 5
+  },
+  {
+    "floor": 6,
+    "number": 6101,
+    "beds": 5
+  },
+  {
+    "floor": 6,
+    "number": 6107,
+    "beds": 5
+  },
+  {
+    "floor": 6,
+    "number": 6113,
+    "beds": 5
+  },
+  {
+    "floor": 6,
+    "number": 6117,
+    "beds": 5
+  },
+  {
+    "floor": 7,
+    "number": 7003,
+    "beds": 4
+  },
+  {
+    "floor": 7,
+    "number": 7007,
+    "beds": 4
+  },
+  {
+    "floor": 7,
+    "number": 7013,
+    "beds": 4
+  },
+  {
+    "floor": 7,
+    "number": 7019,
+    "beds": 4
+  },
+  {
+    "floor": 7,
+    "number": 7024,
+    "beds": 5
+  },
+  {
+    "floor": 7,
+    "number": 7033,
+    "beds": 3
+  },
+  {
+    "floor": 7,
+    "number": 7037,
+    "beds": 6
+  },
+  {
+    "floor": 7,
+    "number": 7042,
+    "beds": 3
+  },
+  {
+    "floor": 7,
+    "number": 7046,
+    "beds": 6
+  },
+  {
+    "floor": 7,
+    "number": 7051,
+    "beds": 3
+  },
+  {
+    "floor": 7,
+    "number": 7056,
+    "beds": 6
+  },
+  {
+    "floor": 7,
+    "number": 7061,
+    "beds": 3
+  },
+  {
+    "floor": 7,
+    "number": 7065,
+    "beds": 6
+  },
+  {
+    "floor": 7,
+    "number": 7071,
+    "beds": 3
+  },
+  {
+    "floor": 7,
+    "number": 7074,
+    "beds": 6
+  },
+  {
+    "floor": 7,
+    "number": 7079,
+    "beds": 3
+  },
+  {
+    "floor": 7,
+    "number": 7084,
+    "beds": 6
+  },
+  {
+    "floor": 7,
+    "number": 7089,
+    "beds": 6
+  },
+  {
+    "floor": 7,
+    "number": 7096,
+    "beds": 5
+  },
+  {
+    "floor": 7,
+    "number": 7101,
+    "beds": 4
+  },
+  {
+    "floor": 7,
+    "number": 7107,
+    "beds": 4
+  },
+  {
+    "floor": 7,
+    "number": 7113,
+    "beds": 4
+  },
+  {
+    "floor": 7,
+    "number": 7117,
+    "beds": 4
+  },
+  {
+    "floor": 8,
+    "number": 8003,
+    "beds": 4
+  },
+  {
+    "floor": 8,
+    "number": 8007,
+    "beds": 4
+  },
+  {
+    "floor": 8,
+    "number": 8013,
+    "beds": 4
+  },
+  {
+    "floor": 8,
+    "number": 8019,
+    "beds": 4
+  },
+  {
+    "floor": 8,
+    "number": 8024,
+    "beds": 5
+  },
+  {
+    "floor": 8,
+    "number": 8033,
+    "beds": 3
+  },
+  {
+    "floor": 8,
+    "number": 8037,
+    "beds": 6
+  },
+  {
+    "floor": 8,
+    "number": 8042,
+    "beds": 3
+  },
+  {
+    "floor": 8,
+    "number": 8046,
+    "beds": 6
+  },
+  {
+    "floor": 8,
+    "number": 8051,
+    "beds": 3
+  },
+  {
+    "floor": 8,
+    "number": 8056,
+    "beds": 6
+  },
+  {
+    "floor": 8,
+    "number": 8061,
+    "beds": 3
+  },
+  {
+    "floor": 8,
+    "number": 8065,
+    "beds": 6
+  },
+  {
+    "floor": 8,
+    "number": 8071,
+    "beds": 3
+  },
+  {
+    "floor": 8,
+    "number": 8074,
+    "beds": 6
+  },
+  {
+    "floor": 8,
+    "number": 8079,
+    "beds": 3
+  },
+  {
+    "floor": 8,
+    "number": 8084,
+    "beds": 6
+  },
+  {
+    "floor": 8,
+    "number": 8089,
+    "beds": 6
+  },
+  {
+    "floor": 8,
+    "number": 8096,
+    "beds": 5
+  },
+  {
+    "floor": 8,
+    "number": 8101,
+    "beds": 4
+  },
+  {
+    "floor": 8,
+    "number": 8107,
+    "beds": 4
+  },
+  {
+    "floor": 8,
+    "number": 8113,
+    "beds": 4
+  },
+  {
+    "floor": 8,
+    "number": 8117,
+    "beds": 4
+  }
+]

--- a/shared/common-resources/src/iosMain/kotlin/dev/nonoxy/residetrack/common/resources/IosFileResourceReader.kt
+++ b/shared/common-resources/src/iosMain/kotlin/dev/nonoxy/residetrack/common/resources/IosFileResourceReader.kt
@@ -1,0 +1,13 @@
+package dev.nonoxy.residetrack.common.resources
+
+import dev.icerock.moko.resources.FileResource
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+internal class IosFileResourceReader : FileResourceReader {
+
+    override suspend fun readText(resource: FileResource): String =
+        withContext(Dispatchers.Default) {
+            resource.readText()
+        }
+}

--- a/shared/common-resources/src/iosMain/kotlin/dev/nonoxy/residetrack/common/resources/di/CommonResourcesModule.ios.kt
+++ b/shared/common-resources/src/iosMain/kotlin/dev/nonoxy/residetrack/common/resources/di/CommonResourcesModule.ios.kt
@@ -1,5 +1,7 @@
 package dev.nonoxy.residetrack.common.resources.di
 
+import dev.nonoxy.residetrack.common.resources.FileResourceReader
+import dev.nonoxy.residetrack.common.resources.IosFileResourceReader
 import dev.nonoxy.residetrack.common.resources.IosStringConverter
 import dev.nonoxy.residetrack.common.resources.StringConverter
 import org.koin.core.module.Module
@@ -9,4 +11,6 @@ import org.koin.dsl.module
 internal actual val platformResourcesModule: Module = module {
 
     factoryOf<StringConverter>(::IosStringConverter)
+
+    factoryOf<FileResourceReader>(::IosFileResourceReader)
 }

--- a/shared/core-database/src/commonMain/kotlin/dev/nonoxy/residetrack/core/database/dao/RoomDao.kt
+++ b/shared/core-database/src/commonMain/kotlin/dev/nonoxy/residetrack/core/database/dao/RoomDao.kt
@@ -20,8 +20,14 @@ abstract class RoomDao {
     @Query("SELECT * FROM rooms WHERE id = :roomId")
     abstract suspend fun getRoomById(roomId: Long): RoomEntity?
 
+    @Query("SELECT COUNT(*) FROM rooms")
+    abstract suspend fun getRoomsCount(): Int
+
     @Insert(onConflict = REPLACE)
     abstract suspend fun insertRoom(room: RoomEntity): Long
+
+    @Insert
+    abstract suspend fun insertRooms(rooms: List<RoomEntity>)
 
     @Update
     abstract suspend fun updateRoom(room: RoomEntity)

--- a/shared/core-initializer/build.gradle.kts
+++ b/shared/core-initializer/build.gradle.kts
@@ -1,0 +1,15 @@
+import extensions.androidLibraryConfig
+import extensions.commonMainDependencies
+import extensions.implementations
+
+plugins {
+    alias(libs.plugins.conventionPlugin.kmpLibrary)
+}
+
+androidLibraryConfig {
+    namespace = "dev.nonoxy.residetrack.core.initializer"
+}
+
+commonMainDependencies {
+    implementations(projects.shared.common)
+}

--- a/shared/core-initializer/src/commonMain/kotlin/dev/nonoxy/residetrack/core/initializer/AppInitializer.kt
+++ b/shared/core-initializer/src/commonMain/kotlin/dev/nonoxy/residetrack/core/initializer/AppInitializer.kt
@@ -1,0 +1,52 @@
+package dev.nonoxy.residetrack.core.initializer
+
+import dev.nonoxy.residetrack.common.utils.coRunCatching
+import io.github.aakira.napier.Napier
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.supervisorScope
+
+/**
+ * Runs all registered [Initializer]s grouped by [Initializer.priority].
+ *
+ * Within a priority group the initializers run concurrently; groups run sequentially in ascending
+ * priority order, so a group only starts once the previous one has fully completed.
+ *
+ * Critical initializers (default) propagate failures and abort startup. Non-critical ones have their
+ * failure logged and swallowed so it does not affect siblings or the rest of startup.
+ */
+class AppInitializer(
+    private val initializers: List<Initializer>,
+) {
+
+    suspend fun run() {
+        initializers
+            .groupBy { initializer -> initializer.priority }
+            .toList()
+            .sortedBy { (priority, _) -> priority }
+            .forEach { (_, group) ->
+                supervisorScope {
+                    group
+                        .map { initializer -> async { initializer.runSafely() } }
+                        .awaitAll()
+                }
+            }
+    }
+
+    private suspend fun Initializer.runSafely() {
+        if (isCritical) {
+            initialize()
+            return
+        }
+
+        coRunCatching(
+            tryBlock = { initialize() },
+            catchBlock = { throwable ->
+                Napier.e(
+                    throwable = throwable,
+                    message = "Initializer ${this::class.simpleName} failed",
+                )
+            }
+        )
+    }
+}

--- a/shared/core-initializer/src/commonMain/kotlin/dev/nonoxy/residetrack/core/initializer/Initializer.kt
+++ b/shared/core-initializer/src/commonMain/kotlin/dev/nonoxy/residetrack/core/initializer/Initializer.kt
@@ -1,0 +1,23 @@
+package dev.nonoxy.residetrack.core.initializer
+
+/**
+ * A single startup task executed by [AppInitializer] before the app's first screen is shown.
+ *
+ * Initializers are grouped by [priority]: all initializers sharing a priority run concurrently,
+ * while different priorities run sequentially in ascending order (a barrier between groups). Use the
+ * same priority for independent tasks and a higher priority for tasks that must run after others.
+ */
+interface Initializer {
+
+    /** Lower runs first. Same value within a group runs in parallel. */
+    val priority: Int
+
+    /**
+     * When `true` (default), a thrown exception aborts startup. When `false`, the failure is caught
+     * and logged so the remaining startup continues.
+     */
+    val isCritical: Boolean
+        get() = true
+
+    suspend fun initialize()
+}

--- a/shared/core-initializer/src/commonMain/kotlin/dev/nonoxy/residetrack/core/initializer/di/CoreInitializerModule.kt
+++ b/shared/core-initializer/src/commonMain/kotlin/dev/nonoxy/residetrack/core/initializer/di/CoreInitializerModule.kt
@@ -1,0 +1,12 @@
+package dev.nonoxy.residetrack.core.initializer.di
+
+import dev.nonoxy.residetrack.core.initializer.AppInitializer
+import org.koin.dsl.module
+
+val coreInitializerModule = module {
+
+    // Collects every Initializer bound across feature modules via getAll().
+    single {
+        AppInitializer(initializers = getAll())
+    }
+}

--- a/shared/core-navigation/src/commonMain/kotlin/dev/nonoxy/residetrack/core/navigation/Screen.kt
+++ b/shared/core-navigation/src/commonMain/kotlin/dev/nonoxy/residetrack/core/navigation/Screen.kt
@@ -1,17 +1,3 @@
 package dev.nonoxy.residetrack.core.navigation
 
-import kotlinx.serialization.Serializable
-
 interface Screen
-
-@Serializable
-data object RoomsRoute : Screen
-
-@Serializable
-data object AddRoomRoute : Screen
-
-@Serializable
-data class ManageStudentsExistingRoomRoute(val roomId: String) : Screen
-
-@Serializable
-data object ManageStudentsDraftRoomRoute : Screen

--- a/shared/feature-add-room/ui/build.gradle.kts
+++ b/shared/feature-add-room/ui/build.gradle.kts
@@ -5,6 +5,7 @@ import extensions.implementations
 plugins {
     alias(libs.plugins.conventionPlugin.kmpFeatureSetup)
     alias(libs.plugins.conventionPlugin.composeMultiplatformSetup)
+    alias(libs.plugins.conventionPlugin.jsonSerialization)
 }
 
 androidLibraryConfig {

--- a/shared/feature-add-room/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/add_room/ui/api/FeatureAddRoomScreenApi.kt
+++ b/shared/feature-add-room/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/add_room/ui/api/FeatureAddRoomScreenApi.kt
@@ -6,14 +6,26 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
-import dev.nonoxy.residetrack.core.navigation.AddRoomRoute
+import dev.nonoxy.residetrack.core.navigation.Screen
 import dev.nonoxy.residetrack.core.navigation.bottomsheet.ModalBottomSheetConfiguration
 import dev.nonoxy.residetrack.core.navigation.bottomsheet.bottomSheet
 import dev.nonoxy.residetrack.core.navigation.navigateOnResumed
 import dev.nonoxy.residetrack.feature.add_room.ui.AddRoomScreen
+import kotlinx.serialization.Serializable
 
-fun NavController.navigateToAddRoomScreen() {
-    navigateOnResumed(AddRoomRoute)
+@Serializable
+data object AddRoomRoute : Screen
+
+fun NavController.navigateToAddRoomScreen(
+    popUpInclusive: Boolean = true,
+    popUpToScreen: Screen? = null,
+) {
+    navigateOnResumed(AddRoomRoute) {
+        launchSingleTop = true
+        popUpToScreen?.let { screen ->
+            popUpTo(screen) { inclusive = popUpInclusive }
+        }
+    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/shared/feature-manage-students/ui/build.gradle.kts
+++ b/shared/feature-manage-students/ui/build.gradle.kts
@@ -5,6 +5,7 @@ import extensions.implementations
 plugins {
     alias(libs.plugins.conventionPlugin.kmpFeatureSetup)
     alias(libs.plugins.conventionPlugin.composeMultiplatformSetup)
+    alias(libs.plugins.conventionPlugin.jsonSerialization)
 }
 
 androidLibraryConfig {

--- a/shared/feature-manage-students/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/manage_students/ui/api/FeatureManageStudentsScreenApi.kt
+++ b/shared/feature-manage-students/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/manage_students/ui/api/FeatureManageStudentsScreenApi.kt
@@ -7,22 +7,45 @@ import androidx.compose.ui.Modifier
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.toRoute
-import dev.nonoxy.residetrack.core.navigation.ManageStudentsDraftRoomRoute
-import dev.nonoxy.residetrack.core.navigation.ManageStudentsExistingRoomRoute
+import dev.nonoxy.residetrack.core.navigation.Screen
 import dev.nonoxy.residetrack.core.navigation.bottomsheet.ModalBottomSheetConfiguration
 import dev.nonoxy.residetrack.core.navigation.bottomsheet.bottomSheet
 import dev.nonoxy.residetrack.core.navigation.navigateOnResumed
 import dev.nonoxy.residetrack.feature.manage_students.api.models.ManageStudentsMode
 import dev.nonoxy.residetrack.feature.manage_students.ui.ManageStudentsScreen
+import kotlinx.serialization.Serializable
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.parameter.parametersOf
 
-fun NavController.navigateToManageStudentsExistingRoom(roomId: String) {
-    navigateOnResumed(ManageStudentsExistingRoomRoute(roomId))
+@Serializable
+data class ManageStudentsExistingRoomRoute(val roomId: String) : Screen
+
+@Serializable
+data object ManageStudentsDraftRoomRoute : Screen
+
+fun NavController.navigateToManageStudentsExistingRoom(
+    roomId: String,
+    popUpInclusive: Boolean = true,
+    popUpToScreen: Screen? = null,
+) {
+    navigateOnResumed(ManageStudentsExistingRoomRoute(roomId)) {
+        launchSingleTop = true
+        popUpToScreen?.let { screen ->
+            popUpTo(screen) { inclusive = popUpInclusive }
+        }
+    }
 }
 
-fun NavController.navigateToManageStudentsDraftRoom() {
-    navigateOnResumed(ManageStudentsDraftRoomRoute)
+fun NavController.navigateToManageStudentsDraftRoom(
+    popUpInclusive: Boolean = true,
+    popUpToScreen: Screen? = null,
+) {
+    navigateOnResumed(ManageStudentsDraftRoomRoute) {
+        launchSingleTop = true
+        popUpToScreen?.let { screen ->
+            popUpTo(screen) { inclusive = popUpInclusive }
+        }
+    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/shared/feature-rooms/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/di/FeatureRoomsImplModule.kt
+++ b/shared/feature-rooms/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/di/FeatureRoomsImplModule.kt
@@ -9,9 +9,15 @@ import dev.nonoxy.residetrack.feature.rooms.impl.data.mappers.RoomMapperImpl
 import dev.nonoxy.residetrack.feature.rooms.impl.data.mappers.StudentMapper
 import dev.nonoxy.residetrack.feature.rooms.impl.data.mappers.StudentMapperImpl
 import dev.nonoxy.residetrack.feature.rooms.impl.domain.RoomsStoreFactory
+import dev.nonoxy.residetrack.feature.rooms.impl.domain.seed.RoomsSeedInitializer
+import dev.nonoxy.residetrack.core.initializer.Initializer
+import org.koin.core.module.dsl.factoryOf
+import org.koin.dsl.bind
 import org.koin.dsl.module
 
 val featureRoomsImplModule = module {
+
+    factoryOf(::RoomsSeedInitializer) bind Initializer::class
 
     factory<StudentMapper> {
         StudentMapperImpl()

--- a/shared/feature-rooms/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/domain/seed/RoomSeed.kt
+++ b/shared/feature-rooms/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/domain/seed/RoomSeed.kt
@@ -1,0 +1,11 @@
+package dev.nonoxy.residetrack.feature.rooms.impl.domain.seed
+
+import kotlinx.serialization.Serializable
+
+/** One row of the prepopulated room structure in `rooms_seed.json`. */
+@Serializable
+internal data class RoomSeed(
+    val floor: Int,
+    val number: Int,
+    val beds: Int,
+)

--- a/shared/feature-rooms/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/domain/seed/RoomsSeedInitializer.kt
+++ b/shared/feature-rooms/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/domain/seed/RoomsSeedInitializer.kt
@@ -1,0 +1,44 @@
+package dev.nonoxy.residetrack.feature.rooms.impl.domain.seed
+
+import dev.nonoxy.residetrack.common.resources.FileResourceReader
+import dev.nonoxy.residetrack.core.database.dao.RoomDao
+import dev.nonoxy.residetrack.core.database.entities.RoomEntity
+import dev.nonoxy.residetrack.core.initializer.Initializer
+import dev.nonoxy.residetrack.res.MR
+import kotlinx.serialization.json.Json
+
+/**
+ * Seeds the fixed building structure (floors / rooms / beds) on first launch.
+ *
+ * The room layout is known up front and ships as `rooms_seed.json`. This runs once: if the table
+ * already holds rooms it does nothing, so user-managed students are never touched on later launches.
+ */
+internal class RoomsSeedInitializer(
+    private val roomDao: RoomDao,
+    private val fileResourceReader: FileResourceReader,
+    private val json: Json,
+) : Initializer {
+
+    override val priority: Int = SEED_PRIORITY
+
+    override suspend fun initialize() {
+        if (roomDao.getRoomsCount() > 0) return
+
+        val rawJson = fileResourceReader.readText(MR.files.rooms_seed_json)
+        val rooms = json.decodeFromString<List<RoomSeed>>(rawJson)
+
+        roomDao.insertRooms(
+            rooms.map { seed ->
+                RoomEntity(
+                    floorNumber = seed.floor,
+                    roomNumber = seed.number,
+                    bedsCount = seed.beds,
+                )
+            }
+        )
+    }
+
+    private companion object {
+        const val SEED_PRIORITY = 0
+    }
+}

--- a/shared/feature-rooms/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/ui/api/FeatureRoomsScreenApi.kt
+++ b/shared/feature-rooms/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/ui/api/FeatureRoomsScreenApi.kt
@@ -3,12 +3,24 @@ package dev.nonoxy.residetrack.feature.rooms.ui.api
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
-import dev.nonoxy.residetrack.core.navigation.RoomsRoute
+import dev.nonoxy.residetrack.core.navigation.Screen
 import dev.nonoxy.residetrack.core.navigation.navigateOnResumed
 import dev.nonoxy.residetrack.feature.rooms.ui.RoomsScreen
+import kotlinx.serialization.Serializable
 
-fun NavController.navigateToRoomsScreen() {
-    navigateOnResumed(RoomsRoute)
+@Serializable
+data object RoomsRoute : Screen
+
+fun NavController.navigateToRoomsScreen(
+    popUpInclusive: Boolean = true,
+    popUpToScreen: Screen? = null,
+) {
+    navigateOnResumed(RoomsRoute) {
+        launchSingleTop = true
+        popUpToScreen?.let { screen ->
+            popUpTo(screen) { inclusive = popUpInclusive }
+        }
+    }
 }
 
 fun NavGraphBuilder.composableRoomsScreen(

--- a/shared/feature-splash/presentation/build.gradle.kts
+++ b/shared/feature-splash/presentation/build.gradle.kts
@@ -4,17 +4,14 @@ import extensions.implementations
 
 plugins {
     alias(libs.plugins.conventionPlugin.kmpFeatureSetup)
-    alias(libs.plugins.conventionPlugin.jsonSerialization)
 }
 
 androidLibraryConfig {
-    namespace = "dev.nonoxy.residetrack.feature.rooms.impl"
+    namespace = "dev.nonoxy.residetrack.feature.splash.presentation"
 }
 
 commonMainDependencies {
     implementations(
-        projects.shared.coreDatabase,
         projects.shared.coreInitializer,
-        projects.shared.commonResources,
     )
 }

--- a/shared/feature-splash/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/splash/presentation/SplashScreenViewModel.kt
+++ b/shared/feature-splash/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/splash/presentation/SplashScreenViewModel.kt
@@ -1,0 +1,19 @@
+package dev.nonoxy.residetrack.feature.splash.presentation
+
+import androidx.lifecycle.viewModelScope
+import dev.nonoxy.residetrack.core.initializer.AppInitializer
+import dev.nonoxy.residetrack.core.presentation.viewmodel.BaseViewModel
+import dev.nonoxy.residetrack.feature.splash.presentation.models.UiSplashLabel
+import kotlinx.coroutines.launch
+
+class SplashScreenViewModel internal constructor(
+    private val appInitializer: AppInitializer,
+) : BaseViewModel<Unit, UiSplashLabel>(initialState = Unit) {
+
+    init {
+        viewModelScope.launch {
+            appInitializer.run()
+            acceptLabel(UiSplashLabel.NavigateToRooms)
+        }
+    }
+}

--- a/shared/feature-splash/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/splash/presentation/di/FeatureSplashPresentationModule.kt
+++ b/shared/feature-splash/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/splash/presentation/di/FeatureSplashPresentationModule.kt
@@ -1,0 +1,10 @@
+package dev.nonoxy.residetrack.feature.splash.presentation.di
+
+import dev.nonoxy.residetrack.feature.splash.presentation.SplashScreenViewModel
+import org.koin.core.module.dsl.viewModelOf
+import org.koin.dsl.module
+
+val featureSplashPresentationModule = module {
+
+    viewModelOf(::SplashScreenViewModel)
+}

--- a/shared/feature-splash/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/splash/presentation/models/UiSplashLabel.kt
+++ b/shared/feature-splash/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/splash/presentation/models/UiSplashLabel.kt
@@ -1,0 +1,5 @@
+package dev.nonoxy.residetrack.feature.splash.presentation.models
+
+sealed interface UiSplashLabel {
+    data object NavigateToRooms : UiSplashLabel
+}

--- a/shared/feature-splash/ui/build.gradle.kts
+++ b/shared/feature-splash/ui/build.gradle.kts
@@ -1,6 +1,4 @@
 import extensions.androidLibraryConfig
-import extensions.commonMainDependencies
-import extensions.implementations
 
 plugins {
     alias(libs.plugins.conventionPlugin.kmpFeatureSetup)
@@ -9,11 +7,5 @@ plugins {
 }
 
 androidLibraryConfig {
-    namespace = "dev.nonoxy.residetrack.feature.rooms.ui"
-}
-
-commonMainDependencies {
-    implementations(
-        libs.kotlin.immutableCollections,
-    )
+    namespace = "dev.nonoxy.residetrack.feature.splash.ui"
 }

--- a/shared/feature-splash/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/splash/ui/SplashScreen.kt
+++ b/shared/feature-splash/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/splash/ui/SplashScreen.kt
@@ -1,0 +1,35 @@
+package dev.nonoxy.residetrack.feature.splash.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import dev.nonoxy.residetrack.common.ui.common.utils.CollectFlow
+import dev.nonoxy.residetrack.feature.splash.presentation.SplashScreenViewModel
+import dev.nonoxy.residetrack.feature.splash.presentation.models.UiSplashLabel
+import org.koin.compose.viewmodel.koinViewModel
+
+@Composable
+internal fun SplashScreen(
+    onNavigateToRooms: () -> Unit,
+    viewModel: SplashScreenViewModel = koinViewModel(),
+) {
+    viewModel.label.CollectFlow { label ->
+        when (label) {
+            UiSplashLabel.NavigateToRooms -> onNavigateToRooms()
+        }
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background),
+        contentAlignment = Alignment.Center,
+    ) {
+        CircularProgressIndicator(color = MaterialTheme.colorScheme.primary)
+    }
+}

--- a/shared/feature-splash/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/splash/ui/api/FeatureSplashScreenApi.kt
+++ b/shared/feature-splash/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/splash/ui/api/FeatureSplashScreenApi.kt
@@ -1,0 +1,18 @@
+package dev.nonoxy.residetrack.feature.splash.ui.api
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import dev.nonoxy.residetrack.core.navigation.Screen
+import dev.nonoxy.residetrack.feature.splash.ui.SplashScreen
+import kotlinx.serialization.Serializable
+
+@Serializable
+data object SplashRoute : Screen
+
+fun NavGraphBuilder.composableSplashScreen(
+    onNavigateToRooms: () -> Unit,
+) {
+    composable<SplashRoute> {
+        SplashScreen(onNavigateToRooms = onNavigateToRooms)
+    }
+}

--- a/shared/main/src/commonMain/kotlin/dev/nonoxy/residetrack/di/Koin.kt
+++ b/shared/main/src/commonMain/kotlin/dev/nonoxy/residetrack/di/Koin.kt
@@ -2,6 +2,8 @@ package dev.nonoxy.residetrack.di
 
 import dev.nonoxy.residetrack.common.di.commonModule
 import dev.nonoxy.residetrack.core.database.di.coreDatabaseModule
+import dev.nonoxy.residetrack.core.initializer.di.coreInitializerModule
+import dev.nonoxy.residetrack.feature.splash.presentation.di.featureSplashPresentationModule
 import dev.nonoxy.residetrack.feature.add_room.impl.di.featureAddRoomImplModule
 import dev.nonoxy.residetrack.feature.add_room.presentation.di.featureAddRoomPresentationModule
 import dev.nonoxy.residetrack.feature.manage_students.impl.di.featureManageStudentsImplModule
@@ -26,6 +28,9 @@ fun initKoin(appDeclaration: KoinAppDeclaration) {
             coreDomainModule,
             coreMVIKotlinModule,
             coreDatabaseModule,
+            coreInitializerModule,
+
+            featureSplashPresentationModule,
 
             featureRoomsImplModule,
             featureRoomsPresentationModule,

--- a/shared/main/src/commonMain/kotlin/dev/nonoxy/residetrack/navigation/ResideTrackNavHost.kt
+++ b/shared/main/src/commonMain/kotlin/dev/nonoxy/residetrack/navigation/ResideTrackNavHost.kt
@@ -5,9 +5,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.rememberNavController
-import dev.nonoxy.residetrack.core.navigation.RoomsRoute
 import dev.nonoxy.residetrack.core.navigation.bottomsheet.ModalBottomSheetLayout
 import dev.nonoxy.residetrack.core.navigation.bottomsheet.rememberModalBottomSheetNavigator
+import dev.nonoxy.residetrack.feature.splash.ui.api.SplashRoute
+import dev.nonoxy.residetrack.feature.splash.ui.api.composableSplashScreen
+import dev.nonoxy.residetrack.feature.rooms.ui.api.navigateToRoomsScreen
 import dev.nonoxy.residetrack.feature.add_room.ui.api.bottomSheetAddRoomScreen
 import dev.nonoxy.residetrack.feature.add_room.ui.api.navigateToAddRoomScreen
 import dev.nonoxy.residetrack.feature.manage_students.ui.api.bottomSheetManageStudentsExistingRoom
@@ -28,8 +30,14 @@ internal fun ResideTrackNavHost(
         NavHost(
             modifier = modifier,
             navController = navController,
-            startDestination = RoomsRoute
+            startDestination = SplashRoute
         ) {
+            composableSplashScreen(
+                onNavigateToRooms = {
+                    navController.navigateToRoomsScreen(popUpToScreen = SplashRoute)
+                }
+            )
+
             composableRoomsScreen(
                 onNavigateToAddRoomScreen = navController::navigateToAddRoomScreen,
                 onNavigateToManageStudentsExistingRoom = navController::navigateToManageStudentsExistingRoom


### PR DESCRIPTION
## Что

Стартовый pipeline инициализации приложения + предзаполнение фиксированной структуры здания (этажи/комнаты/койки) при первом запуске. Комнаты — статичная структура, теперь шипятся с приложением, а не вводятся руками.

## Изменения

**`:shared:core-initializer` (новый модуль)**
- `Initializer` — интерфейс (`priority`, `isCritical`, `suspend initialize()`)
- `AppInitializer` — группировка по `priority`: внутри группы параллельно, между группами барьер. Некритичные фейлы логируются и глотаются, критичные — валят старт.

**Сид комнат**
- `rooms_seed.json` (125 комнат) через moko-resources `MR.files`
- `FileResourceReader` — шим над платформенными read-API moko (как `StringConverter`)
- `RoomsSeedInitializer` — сид один раз, guard `RoomDao.getRoomsCount()`
- `RoomDao`: `getRoomsCount()` + batch `insertRooms()`

**Сплеш**
- `:shared:feature-splash` (presentation + ui) — гейт навигации на время init. `SplashScreenViewModel` гонит `AppInitializer`, затем шлёт label на навигацию (не стейт).

**Навигация (рефактор по эталону)**
- `Screen` — чистый маркерный интерфейс; каждый `Route` переехал в свой `feature/ui/api`
- Единый контракт `navigateTo*(popUpInclusive, popUpToScreen)`

## Проверки
- Компиляция Android (`compileAndroidMain`) + iOS klib (`compileKotlinIosSimulatorArm64`) ✅
- `detekt` ✅
- Pre-push тесты ✅

## Не покрыто
- Runtime-прогон сида вручную не делал — закрывается юнит-тестами на `AppInitializer` (порядок/параллель/critical) и `RoomsSeedInitializer` (guard), следующим шагом.