### PR TITLE
feat: UX fixes — rooms states/places, destructive-action & a11y, discard-changes guard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ captures
 !*.xcodeproj/project.xcworkspace/
 !*.xcworkspace/contents.xcworkspacedata
 **/xcshareddata/WorkspaceSettings.xcsettings
+app_db.db

--- a/shared/common-resources/src/commonMain/moko-resources/base/strings.xml
+++ b/shared/common-resources/src/commonMain/moko-resources/base/strings.xml
@@ -54,6 +54,10 @@
     <string name="remove_student_confirm_message">Запись слушателя будет удалена. Действие нельзя отменить.</string>
     <string name="delete">Удалить</string>
     <string name="select_date">Выбрать дату</string>
+    <string name="discard_changes_title">Отменить изменения?</string>
+    <string name="discard_changes_message">Введённые данные не сохранятся.</string>
+    <string name="discard_changes_confirm">Выйти</string>
+    <string name="keep_editing">Продолжить</string>
 
     <string name="new_student">Новый слушатель</string>
     <string name="student_title">Слушатель %1$s</string>

--- a/shared/common-resources/src/commonMain/moko-resources/base/strings.xml
+++ b/shared/common-resources/src/commonMain/moko-resources/base/strings.xml
@@ -13,6 +13,9 @@
     <string name="rooms_room">Комната</string>
     <string name="rooms_check_in">Заезд</string>
     <string name="rooms_check_out">Выезд</string>
+    <string name="rooms_add_content_description">Добавить комнату</string>
+    <string name="rooms_empty_title">Комнаты не добавлены</string>
+    <string name="rooms_empty_hint">Нажмите + чтобы добавить первую комнату</string>
 
     <!-- Add room feature -->
     <string name="add_room_title">Добавить новую комнату</string>
@@ -47,6 +50,10 @@
     <string name="cancel">Отмена</string>
     <string name="close">Закрыть</string>
     <string name="remove_student">Удалить слушателя</string>
+    <string name="remove_student_confirm_title">Удалить слушателя?</string>
+    <string name="remove_student_confirm_message">Запись слушателя будет удалена. Действие нельзя отменить.</string>
+    <string name="delete">Удалить</string>
+    <string name="select_date">Выбрать дату</string>
 
     <string name="new_student">Новый слушатель</string>
     <string name="student_title">Слушатель %1$s</string>

--- a/shared/common-ui/src/commonMain/kotlin/dev/nonoxy/residetrack/common/ui/common/datepicker/ResideTrackDatePicker.kt
+++ b/shared/common-ui/src/commonMain/kotlin/dev/nonoxy/residetrack/common/ui/common/datepicker/ResideTrackDatePicker.kt
@@ -1,13 +1,22 @@
 package dev.nonoxy.residetrack.common.ui.common.datepicker
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DateRange
 import androidx.compose.material3.DatePicker
 import androidx.compose.material3.DatePickerDefaults
 import androidx.compose.material3.DatePickerDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberDatePickerState
@@ -15,9 +24,16 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
 import dev.nonoxy.residetrack.common.ui.theme.ResideTrackTheme
+import dev.nonoxy.residetrack.common.ui.theme.padding_size_12
+import dev.nonoxy.residetrack.common.ui.theme.size_24
+import dev.nonoxy.residetrack.common.ui.theme.size_48
+import dev.icerock.moko.resources.compose.stringResource
+import dev.nonoxy.residetrack.res.MR
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -35,14 +51,26 @@ fun ResideTrackDatePicker(
     Row(
         modifier = modifier
             .fillMaxWidth()
+            .defaultMinSize(minHeight = size_48)
+            .clip(ResideTrackTheme.shapes.cornerRadius10)
             .background(
                 color = ResideTrackTheme.colors.surface,
                 shape = ResideTrackTheme.shapes.cornerRadius10
             )
-            .clip(ResideTrackTheme.shapes.cornerRadius10)
+            .border(
+                border = BorderStroke(
+                    width = 1.dp,
+                    color = ResideTrackTheme.colors.borderDefault
+                ),
+                shape = ResideTrackTheme.shapes.cornerRadius10
+            )
             .clickable { onShowDatePickerStateChange(true) }
+            .padding(horizontal = padding_size_12),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
     ) {
         Text(
+            modifier = Modifier.weight(1f),
             text = value.ifBlank { placeholder },
             style = ResideTrackTheme.typography.paragraph.copy(
                 color = if (value.isBlank()) {
@@ -51,6 +79,13 @@ fun ResideTrackDatePicker(
                     ResideTrackTheme.colors.textPrimary
                 }
             )
+        )
+
+        Icon(
+            modifier = Modifier.size(size_24),
+            imageVector = Icons.Default.DateRange,
+            contentDescription = stringResource(MR.strings.select_date),
+            tint = ResideTrackTheme.colors.textCaption
         )
     }
 

--- a/shared/common-ui/src/commonMain/kotlin/dev/nonoxy/residetrack/common/ui/common/dialog/DiscardChangesDialog.kt
+++ b/shared/common-ui/src/commonMain/kotlin/dev/nonoxy/residetrack/common/ui/common/dialog/DiscardChangesDialog.kt
@@ -1,0 +1,44 @@
+package dev.nonoxy.residetrack.common.ui.common.dialog
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import dev.nonoxy.residetrack.common.ui.theme.ResideTrackTheme
+import dev.icerock.moko.resources.compose.stringResource
+import dev.nonoxy.residetrack.res.MR
+
+/**
+ * Confirmation shown when the user tries to leave a screen with unsaved changes.
+ *
+ * @param onConfirm discard the changes and proceed with leaving.
+ * @param onDismiss keep editing — stay on the screen.
+ */
+@Composable
+fun DiscardChangesDialog(
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text(text = stringResource(MR.strings.discard_changes_title))
+        },
+        text = {
+            Text(text = stringResource(MR.strings.discard_changes_message))
+        },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(
+                    text = stringResource(MR.strings.discard_changes_confirm),
+                    color = ResideTrackTheme.colors.textError
+                )
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(text = stringResource(MR.strings.keep_editing))
+            }
+        }
+    )
+}

--- a/shared/core-navigation/src/commonMain/kotlin/dev/nonoxy/residetrack/core/navigation/bottomsheet/ModalBottomSheetHost.kt
+++ b/shared/core-navigation/src/commonMain/kotlin/dev/nonoxy/residetrack/core/navigation/bottomsheet/ModalBottomSheetHost.kt
@@ -3,12 +3,15 @@ package dev.nonoxy.residetrack.core.navigation.bottomsheet
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetValue
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveableStateHolder
 import androidx.compose.ui.ExperimentalComposeUiApi
@@ -31,9 +34,18 @@ fun ModalBottomSheetHost(
         (currentEntry?.destination as? ModalBottomSheetNavigator.Destination)?.configuration
 
     val scope = rememberCoroutineScope()
+    val dismissDispatcher = remember { SheetDismissDispatcher() }
+    val baseConfirmValueChange = configuration.getConfirmValueChange()
     val sheetState = rememberModalBottomSheetState(
         skipPartiallyExpanded = configuration.getSkipPartiallyExpanded(),
-        confirmValueChange = configuration.getConfirmValueChange()
+        confirmValueChange = { sheetValue ->
+            if (sheetValue == SheetValue.Hidden && dismissDispatcher.hasEnabledCallback) {
+                dismissDispatcher.dispatch()
+                false
+            } else {
+                baseConfirmValueChange(sheetValue)
+            }
+        }
     )
 
     LaunchedEffect(bottomSheetBackStack.size) {
@@ -48,16 +60,24 @@ fun ModalBottomSheetHost(
 
         if (configuration.getProperties().shouldDismissOnBackPress) {
             BackHandler {
-                scope.launch {
-                    sheetState.hide()
+                if (dismissDispatcher.hasEnabledCallback) {
+                    dismissDispatcher.dispatch()
+                } else {
+                    scope.launch {
+                        sheetState.hide()
+                    }
                 }
             }
         }
 
         ModalBottomSheet(
             onDismissRequest = {
-                currentEntry?.let { entry ->
-                    modalBottomSheetNavigator.dismiss(entry)
+                if (dismissDispatcher.hasEnabledCallback) {
+                    dismissDispatcher.dispatch()
+                } else {
+                    currentEntry?.let { entry ->
+                        modalBottomSheetNavigator.dismiss(entry)
+                    }
                 }
             },
             sheetState = sheetState,
@@ -87,7 +107,11 @@ fun ModalBottomSheetHost(
                     backStackEntry.LocalOwnersProvider(saveableStateHolder) {
                         val destination =
                             backStackEntry.destination as ModalBottomSheetNavigator.Destination
-                        destination.content(backStackEntry)
+                        CompositionLocalProvider(
+                            LocalSheetDismissDispatcher provides dismissDispatcher
+                        ) {
+                            destination.content(backStackEntry)
+                        }
                     }
                 }
             }

--- a/shared/core-navigation/src/commonMain/kotlin/dev/nonoxy/residetrack/core/navigation/bottomsheet/SheetDismissGuard.kt
+++ b/shared/core-navigation/src/commonMain/kotlin/dev/nonoxy/residetrack/core/navigation/bottomsheet/SheetDismissGuard.kt
@@ -1,0 +1,78 @@
+package dev.nonoxy.residetrack.core.navigation.bottomsheet
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.staticCompositionLocalOf
+
+/**
+ * A single registered dismiss-veto from bottom-sheet content.
+ *
+ * @property enabled while `true`, the host must not dismiss the sheet on swipe/scrim/back and
+ *   should instead invoke [onBlockedAttempt].
+ * @property onBlockedAttempt fired when a dismiss was blocked — content turns this into an Intent.
+ */
+class SheetDismissCallback internal constructor(
+    internal var enabled: Boolean,
+    internal val onBlockedAttempt: () -> Unit,
+)
+
+/**
+ * Registry that lets bottom-sheet content veto dismiss attempts (swipe / scrim / back press).
+ *
+ * Mirrors the `OnBackPressedDispatcher` pattern: content registers a callback via
+ * [SheetDismissGuard]; the host consults [hasEnabledCallback] before dismissing and calls
+ * [dispatch] when a dismiss is blocked. The host owns the instance; content reaches it through
+ * [LocalSheetDismissDispatcher].
+ */
+class SheetDismissDispatcher internal constructor() {
+    private val callbacks = mutableStateListOf<SheetDismissCallback>()
+
+    /** `true` when at least one registered callback currently vetoes dismissal. */
+    val hasEnabledCallback: Boolean
+        get() = callbacks.any { it.enabled }
+
+    internal fun register(callback: SheetDismissCallback) {
+        callbacks.add(callback)
+    }
+
+    internal fun unregister(callback: SheetDismissCallback) {
+        callbacks.remove(callback)
+    }
+
+    /** Notify the top-most enabled callback that a dismiss attempt was blocked. */
+    fun dispatch() {
+        callbacks.lastOrNull { it.enabled }?.onBlockedAttempt?.invoke()
+    }
+}
+
+val LocalSheetDismissDispatcher = staticCompositionLocalOf<SheetDismissDispatcher> {
+    error("LocalSheetDismissDispatcher not provided. Sheet content must be hosted by ModalBottomSheetHost.")
+}
+
+/**
+ * Registers a dismiss veto for the enclosing bottom sheet.
+ *
+ * While [enabled] is `true`, swipe-down / scrim-tap / back-press will not close the sheet; instead
+ * [onBlockedAttempt] runs (typically sending an Intent to the store, which then decides whether to
+ * show a confirm dialog or close). Registration follows the sheet content lifecycle.
+ */
+@Composable
+fun SheetDismissGuard(
+    enabled: Boolean,
+    onBlockedAttempt: () -> Unit,
+) {
+    val dispatcher = LocalSheetDismissDispatcher.current
+    val currentOnBlocked = rememberUpdatedState(onBlockedAttempt)
+    val callback = remember { SheetDismissCallback(enabled) { currentOnBlocked.value() } }
+
+    SideEffect { callback.enabled = enabled }
+
+    DisposableEffect(dispatcher, callback) {
+        dispatcher.register(callback)
+        onDispose { dispatcher.unregister(callback) }
+    }
+}

--- a/shared/feature-add-room/api/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/add_room/api/store/AddRoomStore.kt
+++ b/shared/feature-add-room/api/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/add_room/api/store/AddRoomStore.kt
@@ -16,7 +16,16 @@ interface AddRoomStore : Store<Intent, State, Label> {
         val isLoading: Boolean = false,
         val isFormValid: Boolean = false,
         val hasExistingRooms: Boolean = false,
+        val showDiscardConfirm: Boolean = false,
     ) {
+        /** Any user-entered input present — used to guard accidental dismiss. */
+        val isDirty: Boolean
+            get() = floorSelection.textField.value.isNotBlank() ||
+                roomNumber.value.isNotBlank() ||
+                bedsSelection.textField.value.isNotBlank() ||
+                floorSelection.showInput ||
+                bedsSelection.showInput
+
         data class TextFieldState(
             val value: String = "",
             val errorKind: AddRoomErrorKind? = null,
@@ -45,6 +54,9 @@ interface AddRoomStore : Store<Intent, State, Label> {
         data object OnCancelClick : Intent
         data object OnToggleFloorInput : Intent
         data object OnToggleBedsInput : Intent
+        data object OnDismissRequested : Intent
+        data object OnDiscardConfirmed : Intent
+        data object OnKeepEditing : Intent
     }
 
     sealed interface Label {

--- a/shared/feature-add-room/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/add_room/impl/domain/AddRoomExecutor.kt
+++ b/shared/feature-add-room/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/add_room/impl/domain/AddRoomExecutor.kt
@@ -37,6 +37,14 @@ internal class AddRoomExecutor(
             Intent.OnCancelClick -> publish(Label.CloseScreen)
             Intent.OnToggleFloorInput -> dispatch(Message.ToggleFloorInput)
             Intent.OnToggleBedsInput -> dispatch(Message.ToggleBedsInput)
+            Intent.OnDismissRequested ->
+                if (state().isDirty) {
+                    dispatch(Message.SetShowDiscardConfirm(show = true))
+                } else {
+                    publish(Label.CloseScreen)
+                }
+            Intent.OnDiscardConfirmed -> publish(Label.CloseScreen)
+            Intent.OnKeepEditing -> dispatch(Message.SetShowDiscardConfirm(show = false))
         }
     }
 

--- a/shared/feature-add-room/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/add_room/impl/domain/AddRoomReducer.kt
+++ b/shared/feature-add-room/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/add_room/impl/domain/AddRoomReducer.kt
@@ -87,5 +87,6 @@ internal class AddRoomReducer : Reducer<State, Message> {
 
         is Message.SetIsFormValid -> copy(isFormValid = msg.isValid)
         is Message.SetIsLoading -> copy(isLoading = msg.isLoading)
+        is Message.SetShowDiscardConfirm -> copy(showDiscardConfirm = msg.show)
     }
 }

--- a/shared/feature-add-room/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/add_room/impl/domain/AddRoomStoreFactory.kt
+++ b/shared/feature-add-room/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/add_room/impl/domain/AddRoomStoreFactory.kt
@@ -61,6 +61,7 @@ internal class AddRoomStoreFactory(
 
         data class SetIsFormValid(val isValid: Boolean) : Message
         data class SetIsLoading(val isLoading: Boolean) : Message
+        data class SetShowDiscardConfirm(val show: Boolean) : Message
     }
 
     /** Wrapper used because `Reducer.reduce` can't carry a triple of nullable values nicely

--- a/shared/feature-add-room/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/add_room/presentation/AddRoomViewModel.kt
+++ b/shared/feature-add-room/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/add_room/presentation/AddRoomViewModel.kt
@@ -47,6 +47,12 @@ class AddRoomViewModel internal constructor(
 
     fun onToggleBedsInput() = store.accept(Intent.OnToggleBedsInput)
 
+    fun onDismissRequested() = store.accept(Intent.OnDismissRequested)
+
+    fun onDiscardConfirmed() = store.accept(Intent.OnDiscardConfirmed)
+
+    fun onKeepEditing() = store.accept(Intent.OnKeepEditing)
+
     override fun onCleared() {
         store.dispose()
         super.onCleared()

--- a/shared/feature-add-room/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/add_room/presentation/mappers/UiAddRoomStateMapper.kt
+++ b/shared/feature-add-room/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/add_room/presentation/mappers/UiAddRoomStateMapper.kt
@@ -33,5 +33,7 @@ internal class UiAddRoomStateMapperImpl : UiAddRoomStateMapper {
         isLoading = item.isLoading,
         isFormValid = item.isFormValid,
         hasExistingRooms = item.hasExistingRooms,
+        isDirty = item.isDirty,
+        showDiscardConfirm = item.showDiscardConfirm,
     )
 }

--- a/shared/feature-add-room/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/add_room/presentation/models/UiAddRoomState.kt
+++ b/shared/feature-add-room/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/add_room/presentation/models/UiAddRoomState.kt
@@ -11,6 +11,8 @@ data class UiAddRoomState(
     val isLoading: Boolean = false,
     val isFormValid: Boolean = false,
     val hasExistingRooms: Boolean = false,
+    val isDirty: Boolean = false,
+    val showDiscardConfirm: Boolean = false,
 ) {
     data class TextField(
         val value: String = "",

--- a/shared/feature-add-room/ui/build.gradle.kts
+++ b/shared/feature-add-room/ui/build.gradle.kts
@@ -15,5 +15,6 @@ androidLibraryConfig {
 commonMainDependencies {
     implementations(
         libs.kotlin.immutableCollections,
+        libs.compose.icons.core,
     )
 }

--- a/shared/feature-add-room/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/add_room/ui/AddRoomScreen.kt
+++ b/shared/feature-add-room/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/add_room/ui/AddRoomScreen.kt
@@ -17,6 +17,8 @@ import dev.nonoxy.residetrack.feature.add_room.presentation.models.UiAddRoomLabe
 import dev.nonoxy.residetrack.feature.add_room.ui.views.AddRoomScreenContent
 import dev.nonoxy.residetrack.common.resources.StringConverter
 import dev.nonoxy.residetrack.common.ui.common.dialog.DialogScaffold
+import dev.nonoxy.residetrack.common.ui.common.dialog.DiscardChangesDialog
+import dev.nonoxy.residetrack.core.navigation.bottomsheet.SheetDismissGuard
 import dev.nonoxy.residetrack.common.ui.common.snackbar.ResideTrackErrorSnackbar
 import dev.nonoxy.residetrack.common.ui.common.snackbar.ResideTrackSnackbar
 import dev.nonoxy.residetrack.common.ui.common.snackbar.SnackbarType
@@ -35,6 +37,17 @@ internal fun AddRoomScreen(
 
     val snackbarHostState = remember { SnackbarHostState() }
     var currentSnackbarType by rememberSaveable { mutableStateOf(SnackbarType.INFO) }
+
+    SheetDismissGuard(enabled = state.isDirty && !state.isLoading) {
+        viewModel.onDismissRequested()
+    }
+
+    if (state.showDiscardConfirm) {
+        DiscardChangesDialog(
+            onConfirm = viewModel::onDiscardConfirmed,
+            onDismiss = viewModel::onKeepEditing,
+        )
+    }
 
     viewModel.label.CollectFlow { label ->
         when (label) {

--- a/shared/feature-add-room/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/add_room/ui/views/SelectionChips.kt
+++ b/shared/feature-add-room/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/add_room/ui/views/SelectionChips.kt
@@ -6,8 +6,12 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -70,15 +74,14 @@ internal fun FloorSelectionChips(
             },
             selected = showInput,
             leadingIcon = {
-                Text(
-                    text = if (showInput) "−" else "+",
-                    style = ResideTrackTheme.typography.head3.copy(
-                        color = if (showInput) {
-                            ResideTrackTheme.colors.white
-                        } else {
-                            ResideTrackTheme.colors.textAccent
-                        }
-                    )
+                Icon(
+                    imageVector = if (showInput) Icons.Default.Close else Icons.Default.Add,
+                    contentDescription = null,
+                    tint = if (showInput) {
+                        ResideTrackTheme.colors.white
+                    } else {
+                        ResideTrackTheme.colors.textAccent
+                    }
                 )
             },
             colors = FilterChipDefaults.filterChipColors(
@@ -140,15 +143,14 @@ internal fun BedsSelectionChips(
             },
             selected = showInput,
             leadingIcon = {
-                Text(
-                    text = if (showInput) "−" else "+",
-                    style = ResideTrackTheme.typography.head3.copy(
-                        color = if (showInput) {
-                            ResideTrackTheme.colors.white
-                        } else {
-                            ResideTrackTheme.colors.textAccent
-                        }
-                    )
+                Icon(
+                    imageVector = if (showInput) Icons.Default.Close else Icons.Default.Add,
+                    contentDescription = null,
+                    tint = if (showInput) {
+                        ResideTrackTheme.colors.white
+                    } else {
+                        ResideTrackTheme.colors.textAccent
+                    }
                 )
             },
             colors = FilterChipDefaults.filterChipColors(

--- a/shared/feature-manage-students/api/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/manage_students/api/store/ManageStudentsStore.kt
+++ b/shared/feature-manage-students/api/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/manage_students/api/store/ManageStudentsStore.kt
@@ -16,6 +16,8 @@ interface ManageStudentsStore : Store<Intent, State, Label> {
         val errorKind: ManageStudentsErrorKind? = null,
         val room: Room? = null,
         val editableStudents: ImmutableList<EditableStudent> = persistentListOf(),
+        val isDirty: Boolean = false,
+        val showDiscardConfirm: Boolean = false,
     ) {
         data class EditableStudent(
             val id: String,
@@ -40,6 +42,9 @@ interface ManageStudentsStore : Store<Intent, State, Label> {
         data class OnCheckOutDateMillisChange(val studentId: String, val millis: Long) : Intent
         data object OnSaveAndClose : Intent
         data object OnClose : Intent
+        data object OnDismissRequested : Intent
+        data object OnDiscardConfirmed : Intent
+        data object OnKeepEditing : Intent
     }
 
     sealed interface Label {

--- a/shared/feature-manage-students/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/manage_students/impl/domain/ManageStudentsExecutor.kt
+++ b/shared/feature-manage-students/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/manage_students/impl/domain/ManageStudentsExecutor.kt
@@ -55,6 +55,14 @@ internal class ManageStudentsExecutor(
             is Intent.OnCheckOutDateMillisChange -> handleCheckOutDateMillisChange(intent.studentId, intent.millis)
             Intent.OnSaveAndClose -> handleSaveAndClose()
             Intent.OnClose -> publish(Label.NavigateBack)
+            Intent.OnDismissRequested ->
+                if (state().isDirty) {
+                    dispatch(Message.SetShowDiscardConfirm(show = true))
+                } else {
+                    publish(Label.NavigateBack)
+                }
+            Intent.OnDiscardConfirmed -> publish(Label.NavigateBack)
+            Intent.OnKeepEditing -> dispatch(Message.SetShowDiscardConfirm(show = false))
         }
     }
 

--- a/shared/feature-manage-students/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/manage_students/impl/domain/ManageStudentsReducer.kt
+++ b/shared/feature-manage-students/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/manage_students/impl/domain/ManageStudentsReducer.kt
@@ -30,10 +30,17 @@ internal class ManageStudentsReducer : Reducer<State, Message> {
             errorKind = null,
             room = msg.room,
             editableStudents = msg.editableStudents,
+            isDirty = false,
+            showDiscardConfirm = false,
         )
 
         is Message.SetEditableStudents -> copy(
             editableStudents = msg.editableStudents,
+            isDirty = true,
+        )
+
+        is Message.SetShowDiscardConfirm -> copy(
+            showDiscardConfirm = msg.show,
         )
     }
 }

--- a/shared/feature-manage-students/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/manage_students/impl/domain/ManageStudentsStoreFactory.kt
+++ b/shared/feature-manage-students/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/manage_students/impl/domain/ManageStudentsStoreFactory.kt
@@ -53,5 +53,7 @@ internal class ManageStudentsStoreFactory(
         data class SetEditableStudents(
             val editableStudents: ImmutableList<State.EditableStudent>,
         ) : Message
+
+        data class SetShowDiscardConfirm(val show: Boolean) : Message
     }
 }

--- a/shared/feature-manage-students/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/manage_students/presentation/ManageStudentsViewModel.kt
+++ b/shared/feature-manage-students/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/manage_students/presentation/ManageStudentsViewModel.kt
@@ -49,6 +49,12 @@ class ManageStudentsViewModel internal constructor(
 
     fun onClose() = store.accept(Intent.OnClose)
 
+    fun onDismissRequested() = store.accept(Intent.OnDismissRequested)
+
+    fun onDiscardConfirmed() = store.accept(Intent.OnDiscardConfirmed)
+
+    fun onKeepEditing() = store.accept(Intent.OnKeepEditing)
+
     override fun onCleared() {
         store.dispose()
         super.onCleared()

--- a/shared/feature-manage-students/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/manage_students/presentation/mappers/UiManageStudentsStateMapper.kt
+++ b/shared/feature-manage-students/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/manage_students/presentation/mappers/UiManageStudentsStateMapper.kt
@@ -30,5 +30,7 @@ internal class UiManageStudentsStateMapperImpl(
                 isNew = st.isNew,
             )
         }.toPersistentList(),
+        isDirty = item.isDirty,
+        showDiscardConfirm = item.showDiscardConfirm,
     )
 }

--- a/shared/feature-manage-students/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/manage_students/presentation/models/UiManageStudentsState.kt
+++ b/shared/feature-manage-students/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/manage_students/presentation/models/UiManageStudentsState.kt
@@ -10,4 +10,6 @@ data class UiManageStudentsState(
     val errorKind: ManageStudentsErrorKind? = null,
     val room: UiRoom? = null,
     val editableStudents: ImmutableList<UiEditableStudent> = persistentListOf(),
+    val isDirty: Boolean = false,
+    val showDiscardConfirm: Boolean = false,
 )

--- a/shared/feature-manage-students/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/manage_students/ui/ManageStudentsScreen.kt
+++ b/shared/feature-manage-students/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/manage_students/ui/ManageStudentsScreen.kt
@@ -17,6 +17,8 @@ import dev.nonoxy.residetrack.feature.manage_students.presentation.models.UiMana
 import dev.nonoxy.residetrack.feature.manage_students.ui.views.ManageStudentsContent
 import dev.nonoxy.residetrack.common.resources.StringConverter
 import dev.nonoxy.residetrack.common.ui.common.dialog.DialogScaffold
+import dev.nonoxy.residetrack.common.ui.common.dialog.DiscardChangesDialog
+import dev.nonoxy.residetrack.core.navigation.bottomsheet.SheetDismissGuard
 import dev.nonoxy.residetrack.common.ui.common.snackbar.ResideTrackErrorSnackbar
 import dev.nonoxy.residetrack.common.ui.common.snackbar.ResideTrackSnackbar
 import dev.nonoxy.residetrack.common.ui.common.snackbar.SnackbarType
@@ -34,6 +36,17 @@ internal fun ManageStudentsScreen(
 
     val snackbarHostState = remember { SnackbarHostState() }
     var currentSnackbarType by rememberSaveable { mutableStateOf(SnackbarType.INFO) }
+
+    SheetDismissGuard(enabled = state.isDirty && !state.isLoading) {
+        viewModel.onDismissRequested()
+    }
+
+    if (state.showDiscardConfirm) {
+        DiscardChangesDialog(
+            onConfirm = viewModel::onDiscardConfirmed,
+            onDismiss = viewModel::onKeepEditing,
+        )
+    }
 
     viewModel.label.CollectFlow { label ->
         when (label) {

--- a/shared/feature-manage-students/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/manage_students/ui/views/ManageStudentsList.kt
+++ b/shared/feature-manage-students/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/manage_students/ui/views/ManageStudentsList.kt
@@ -94,7 +94,7 @@ internal fun ManageStudentsList(
             ) {
                 Icon(
                     imageVector = Icons.Default.Add,
-                    contentDescription = null,
+                    contentDescription = stringResource(MR.strings.add_student),
                 )
                 Spacer(modifier = Modifier.width(padding_size_8))
                 Text(stringResource(MR.strings.add_student))

--- a/shared/feature-manage-students/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/manage_students/ui/views/StudentCardHeader.kt
+++ b/shared/feature-manage-students/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/manage_students/ui/views/StudentCardHeader.kt
@@ -3,15 +3,19 @@ package dev.nonoxy.residetrack.feature.manage_students.ui.views
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.size
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import dev.nonoxy.residetrack.common.ui.theme.ResideTrackTheme
-import dev.nonoxy.residetrack.common.ui.theme.size_24
 import dev.icerock.moko.resources.compose.painterResource
 import dev.icerock.moko.resources.compose.stringResource
 import dev.nonoxy.residetrack.res.MR
@@ -23,6 +27,8 @@ internal fun StudentCardHeader(
     onRemove: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    var showRemoveConfirm by remember { mutableStateOf(false) }
+
     Row(
         modifier = modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceBetween,
@@ -41,15 +47,42 @@ internal fun StudentCardHeader(
             color = ResideTrackTheme.colors.textPrimary
         )
 
-        IconButton(
-            onClick = onRemove,
-            modifier = Modifier.size(size_24)
-        ) {
+        IconButton(onClick = { showRemoveConfirm = true }) {
             Icon(
                 painter = painterResource(MR.images.ic_delete_circle),
-                contentDescription = null,
+                contentDescription = stringResource(MR.strings.remove_student),
                 tint = ResideTrackTheme.colors.textError
             )
         }
+    }
+
+    if (showRemoveConfirm) {
+        AlertDialog(
+            onDismissRequest = { showRemoveConfirm = false },
+            title = {
+                Text(text = stringResource(MR.strings.remove_student_confirm_title))
+            },
+            text = {
+                Text(text = stringResource(MR.strings.remove_student_confirm_message))
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        showRemoveConfirm = false
+                        onRemove()
+                    }
+                ) {
+                    Text(
+                        text = stringResource(MR.strings.delete),
+                        color = ResideTrackTheme.colors.textError
+                    )
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showRemoveConfirm = false }) {
+                    Text(text = stringResource(MR.strings.cancel))
+                }
+            }
+        )
     }
 }

--- a/shared/feature-rooms/api/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/api/store/RoomsStore.kt
+++ b/shared/feature-rooms/api/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/api/store/RoomsStore.kt
@@ -9,12 +9,15 @@ import dev.nonoxy.residetrack.feature.rooms.api.store.RoomsStore.State
 interface RoomsStore : Store<Intent, State, Label> {
 
     data class State(
+        val isLoading: Boolean = false,
+        val isError: Boolean = false,
         val roomsOnFloor: Map<Int, List<Room>> = emptyMap(),
     )
 
     sealed interface Intent {
         data class OnRoomClick(val roomId: Long) : Intent
         data object OnAddRoomClick : Intent
+        data object OnRetry : Intent
     }
 
     sealed interface Label {

--- a/shared/feature-rooms/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/domain/RoomsExecutor.kt
+++ b/shared/feature-rooms/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/domain/RoomsExecutor.kt
@@ -26,16 +26,19 @@ internal class RoomsExecutor(
                 Label.NavigateToManageStudentsExistingRoom(roomId = intent.roomId.toString())
             )
             Intent.OnAddRoomClick -> publish(Label.NavigateToAddRoomScreen)
+            Intent.OnRetry -> loadRoomsData()
         }
     }
 
     private suspend fun loadRoomsData() {
-        // TODO: silent error swallow inherited from old ViewModel. When State gains
-        //  isError/isLoading fields (post-Phase 4), dispatch a Message.SetError here.
-        val rooms = roomsRepository.getAllRooms().getOrElse { emptyList() }
-        if (rooms.isNotEmpty()) {
-            val grouped = rooms.groupBy { room -> room.floorNumber }
-            dispatch(Message.SetRoomsOnFloor(roomsOnFloor = grouped))
-        }
+        dispatch(Message.SetIsLoading(isLoading = true))
+        roomsRepository.getAllRooms()
+            .onSuccess { rooms ->
+                val grouped = rooms.groupBy { room -> room.floorNumber }
+                dispatch(Message.SetRoomsOnFloor(roomsOnFloor = grouped))
+            }
+            .onFailure {
+                dispatch(Message.SetError)
+            }
     }
 }

--- a/shared/feature-rooms/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/domain/RoomsReducer.kt
+++ b/shared/feature-rooms/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/domain/RoomsReducer.kt
@@ -7,6 +7,20 @@ import dev.nonoxy.residetrack.feature.rooms.impl.domain.RoomsStoreFactory.Messag
 internal class RoomsReducer : Reducer<State, Message> {
 
     override fun State.reduce(msg: Message): State = when (msg) {
-        is Message.SetRoomsOnFloor -> copy(roomsOnFloor = msg.roomsOnFloor)
+        is Message.SetIsLoading -> copy(
+            isLoading = msg.isLoading,
+            isError = if (msg.isLoading) false else isError,
+        )
+
+        Message.SetError -> copy(
+            isLoading = false,
+            isError = true,
+        )
+
+        is Message.SetRoomsOnFloor -> copy(
+            isLoading = false,
+            isError = false,
+            roomsOnFloor = msg.roomsOnFloor,
+        )
     }
 }

--- a/shared/feature-rooms/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/domain/RoomsStoreFactory.kt
+++ b/shared/feature-rooms/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/domain/RoomsStoreFactory.kt
@@ -38,6 +38,8 @@ internal class RoomsStoreFactory(
     }
 
     internal sealed interface Message {
+        data class SetIsLoading(val isLoading: Boolean) : Message
+        data object SetError : Message
         data class SetRoomsOnFloor(val roomsOnFloor: Map<Int, List<Room>>) : Message
     }
 }

--- a/shared/feature-rooms/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/presentation/RoomsViewModel.kt
+++ b/shared/feature-rooms/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/presentation/RoomsViewModel.kt
@@ -28,6 +28,8 @@ class RoomsViewModel internal constructor(
 
     fun onAddRoomClick() = store.accept(Intent.OnAddRoomClick)
 
+    fun onRetryClick() = store.accept(Intent.OnRetry)
+
     override fun onCleared() {
         store.dispose()
         super.onCleared()

--- a/shared/feature-rooms/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/presentation/mappers/UiRoomsStateMapper.kt
+++ b/shared/feature-rooms/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/presentation/mappers/UiRoomsStateMapper.kt
@@ -13,10 +13,19 @@ internal class UiRoomsStateMapperImpl(
     private val roomMapper: UiRoomMapper
 ) : UiRoomsStateMapper {
 
-    override fun map(item: RoomsStore.State): UiRoomsState =
-        UiRoomsState(
+    override fun map(item: RoomsStore.State): UiRoomsState {
+        val allRooms = item.roomsOnFloor.values.flatten()
+        val totalPlaces = allRooms.sumOf { room -> room.bedsCount }
+        val occupiedPlaces = allRooms.sumOf { room -> room.students.size }
+
+        return UiRoomsState(
+            isLoading = item.isLoading,
+            isError = item.isError,
+            totalPlaces = totalPlaces,
+            availablePlaces = (totalPlaces - occupiedPlaces).coerceAtLeast(0),
             roomsOnFloor = item.roomsOnFloor
                 .mapValues { entry -> entry.value.let(roomMapper::map).toPersistentList() }
                 .toPersistentMap()
         )
+    }
 }

--- a/shared/feature-rooms/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/presentation/models/UiRoomsState.kt
+++ b/shared/feature-rooms/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/presentation/models/UiRoomsState.kt
@@ -5,5 +5,9 @@ import kotlinx.collections.immutable.ImmutableMap
 import kotlinx.collections.immutable.persistentMapOf
 
 data class UiRoomsState(
+    val isLoading: Boolean = false,
+    val isError: Boolean = false,
+    val totalPlaces: Int = 0,
+    val availablePlaces: Int = 0,
     val roomsOnFloor: ImmutableMap<Int, ImmutableList<UiRoom>> = persistentMapOf(),
 )

--- a/shared/feature-rooms/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/ui/RoomsScreen.kt
+++ b/shared/feature-rooms/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/ui/RoomsScreen.kt
@@ -31,6 +31,7 @@ internal fun RoomsScreen(
         state = state,
         onRoomClick = viewModel::onRoomClick,
         onAddRoomClick = viewModel::onAddRoomClick,
+        onRetryClick = viewModel::onRetryClick,
         modifier = Modifier.fillMaxSize()
     )
 }

--- a/shared/feature-rooms/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/ui/views/RoomsEmptyState.kt
+++ b/shared/feature-rooms/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/ui/views/RoomsEmptyState.kt
@@ -1,0 +1,53 @@
+package dev.nonoxy.residetrack.feature.rooms.ui.views
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import dev.nonoxy.residetrack.common.ui.theme.ResideTrackTheme
+import dev.nonoxy.residetrack.common.ui.theme.padding_size_32
+import dev.nonoxy.residetrack.common.ui.theme.padding_size_8
+import dev.icerock.moko.resources.compose.stringResource
+import dev.nonoxy.residetrack.res.MR
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+@Composable
+internal fun RoomsEmptyState(
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .padding(padding_size_32),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text(
+            text = stringResource(MR.strings.rooms_empty_title),
+            style = ResideTrackTheme.typography.head4,
+            color = ResideTrackTheme.colors.textCaption,
+            textAlign = TextAlign.Center
+        )
+        Spacer(modifier = Modifier.height(padding_size_8))
+        Text(
+            text = stringResource(MR.strings.rooms_empty_hint),
+            style = ResideTrackTheme.typography.paragraph,
+            color = ResideTrackTheme.colors.textCaption,
+            textAlign = TextAlign.Center
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun Preview() {
+    ResideTrackTheme {
+        RoomsEmptyState(modifier = Modifier.fillMaxSize())
+    }
+}

--- a/shared/feature-rooms/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/ui/views/RoomsScreenDetails.kt
+++ b/shared/feature-rooms/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/ui/views/RoomsScreenDetails.kt
@@ -15,6 +15,7 @@ import dev.nonoxy.residetrack.common.utils.orEmptyPersist
 import dev.nonoxy.residetrack.feature.rooms.presentation.models.UiRoom
 import dev.nonoxy.residetrack.feature.rooms.presentation.models.UiRoomsState
 import dev.nonoxy.residetrack.feature.rooms.presentation.models.UiStudent
+import dev.nonoxy.residetrack.common.ui.common.state.ShowStateData
 import dev.nonoxy.residetrack.common.ui.theme.ResideTrackTheme
 import dev.nonoxy.residetrack.common.ui.theme.padding_size_16
 import kotlinx.collections.immutable.persistentListOf
@@ -28,41 +29,55 @@ internal fun RoomsScreenDetails(
     state: UiRoomsState,
     onRoomClick: (Long) -> Unit,
     onAddRoomClick: () -> Unit,
+    onRetryClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val pagerState = rememberPagerState { state.roomsOnFloor.keys.size }
-    val scope = rememberCoroutineScope()
+    ShowStateData(
+        modifier = modifier,
+        state = state,
+        isLoading = state.isLoading,
+        isError = state.isError,
+        onRetryClick = onRetryClick,
+    ) { currentState ->
+        val pagerState = rememberPagerState { currentState.roomsOnFloor.keys.size }
+        val scope = rememberCoroutineScope()
 
-    Column(modifier = modifier) {
-        RoomsTopBar(
-            modifier = Modifier.padding(horizontal = padding_size_16),
-            totalPlaces = 0,
-            availablePlaces = 0,
-            onAddRoomClick = onAddRoomClick
-        )
-
-        if (state.roomsOnFloor.keys.size > 1) {
-            RoomsTabRow(
-                modifier = Modifier.fillMaxWidth(),
-                floors = state.roomsOnFloor.keys,
-                selectedTabIndex = pagerState.currentPage,
-                onTabClick = { index ->
-                    scope.launch { pagerState.animateScrollToPage(page = index) }
-                }
+        Column(modifier = Modifier.fillMaxSize()) {
+            RoomsTopBar(
+                modifier = Modifier.padding(horizontal = padding_size_16),
+                totalPlaces = currentState.totalPlaces,
+                availablePlaces = currentState.availablePlaces,
+                onAddRoomClick = onAddRoomClick
             )
-        }
 
-        HorizontalPager(
-            modifier = Modifier.fillMaxSize(),
-            state = pagerState,
-            verticalAlignment = Alignment.Top
-        ) { page ->
-            RoomList(
-                rooms = state.roomsOnFloor.get(
-                    key = state.roomsOnFloor.keys.elementAtOrNull(index = page)
-                ).orEmptyPersist(),
-                onRoomClick = onRoomClick
-            )
+            if (currentState.roomsOnFloor.isEmpty()) {
+                RoomsEmptyState(modifier = Modifier.fillMaxSize())
+                return@Column
+            }
+
+            if (currentState.roomsOnFloor.keys.size > 1) {
+                RoomsTabRow(
+                    modifier = Modifier.fillMaxWidth(),
+                    floors = currentState.roomsOnFloor.keys,
+                    selectedTabIndex = pagerState.currentPage,
+                    onTabClick = { index ->
+                        scope.launch { pagerState.animateScrollToPage(page = index) }
+                    }
+                )
+            }
+
+            HorizontalPager(
+                modifier = Modifier.fillMaxSize(),
+                state = pagerState,
+                verticalAlignment = Alignment.Top
+            ) { page ->
+                RoomList(
+                    rooms = currentState.roomsOnFloor.get(
+                        key = currentState.roomsOnFloor.keys.elementAtOrNull(index = page)
+                    ).orEmptyPersist(),
+                    onRoomClick = onRoomClick
+                )
+            }
         }
     }
 }
@@ -73,6 +88,8 @@ private fun Preview() {
     ResideTrackTheme {
         RoomsScreenDetails(
             state = UiRoomsState(
+                totalPlaces = 8,
+                availablePlaces = 6,
                 roomsOnFloor = persistentMapOf(
                     3 to persistentListOf(
                         UiRoom(
@@ -109,6 +126,7 @@ private fun Preview() {
             ),
             onRoomClick = {},
             onAddRoomClick = {},
+            onRetryClick = {},
             modifier = Modifier.fillMaxSize()
         )
     }

--- a/shared/feature-rooms/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/ui/views/RoomsTopBar.kt
+++ b/shared/feature-rooms/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/ui/views/RoomsTopBar.kt
@@ -37,7 +37,7 @@ internal fun RoomsTopBar(
             IconButton(onClick = onAddRoomClick) {
                 Icon(
                     painter = painterResource(MR.images.ic_add),
-                    contentDescription = null
+                    contentDescription = stringResource(MR.strings.rooms_add_content_description)
                 )
             }
         },


### PR DESCRIPTION
## Что

Две группы UX-фиксов по итогам ревью интерфейса.

### 1. Критичные экранные дыры (`c4d8911`)
- **Rooms loading/error/empty** — `RoomsStore.State` получил `isLoading`/`isError`, `RoomsScreenDetails` обёрнут в `ShowStateData` (лоадер + ошибка + retry), добавлен empty-state (`RoomsEmptyState`). Убран silent-swallow ошибок загрузки в `RoomsExecutor`, добавлен `OnRetry`.
- **Rooms places** — `totalPlaces`/`availablePlaces` считаются из реального state в `UiRoomsStateMapper` (было захардкожено `0`).
- **Удаление студента** — confirm-диалог, тап-таргет 24→48dp, `contentDescription`.
- **Иконки** — глифы `+`/`−` в Add Room → vector icons (`Add`/`Close`); `contentDescription` на action-иконках.
- **DatePicker** — border + календарь-иконка + min-height 48dp + contentDescription.

### 2. Discard-changes guard для bottom sheets (`7b8c35e`)
Случайный свайп/scrim/back больше не теряет введённые данные — спрашивает подтверждение. Чистый MVI:
- **core-navigation**: переиспользуемый `SheetDismissGuard` + `SheetDismissDispatcher` + `LocalSheetDismissDispatcher`; `ModalBottomSheetHost` сверяется с диспетчером в `confirmValueChange`/`BackHandler`/`onDismissRequest`.
- **common-ui**: `DiscardChangesDialog`.
- Колбэк закрытия → Intent → стор решает (грязно → стейт `showDiscardConfirm`; чисто → `Label.Close`). UI тупой.
- `isDirty`: AddRoom — вычисляемое из полей; ManageStudents — флаг в reducer (ловит правки existing-студентов).
- Явные Cancel/Save закрывают сразу; гард ловит только случайные пути.

## Проверки
- ✅ Android `compileDevDebugKotlin`
- ✅ iOS `compileKotlinIosSimulatorArm64`
- ✅ detekt
- ✅ `allTests`

## ⚠️ Не покрыто автоматикой
Жесты bottom sheet (`confirmValueChange` на drag, тайминги закрытия) — нужна ручная проверка на устройстве.

## Сознательно отложено
- Splash error/timeout-ветка — отдельная задача.
- Тесты feature-слоя (reducer/mapper) — инфры тестов в feature-модулях пока нет.