### PR TITLE
fix(ui): brand the text field cursor color

### DIFF
--- a/shared/common-ui/src/commonMain/kotlin/dev/nonoxy/residetrack/common/ui/common/textfield/ResideTrackTextField.kt
+++ b/shared/common-ui/src/commonMain/kotlin/dev/nonoxy/residetrack/common/ui/common/textfield/ResideTrackTextField.kt
@@ -38,7 +38,9 @@ fun ResideTrackTextField(
         errorTextColor = ResideTrackTheme.colors.textPrimary,
         focusedContainerColor = ResideTrackTheme.colors.surface,
         unfocusedContainerColor = ResideTrackTheme.colors.surface,
-        disabledContainerColor = ResideTrackTheme.colors.fillInactive.copy(alpha = 0.1f)
+        disabledContainerColor = ResideTrackTheme.colors.fillInactive.copy(alpha = 0.1f),
+        cursorColor = ResideTrackTheme.colors.textAccent,
+        errorCursorColor = ResideTrackTheme.colors.textError
     ),
     textStyle: TextStyle = ResideTrackTheme.typography.paragraph,
     keyboardType: KeyboardType = KeyboardType.Text,


### PR DESCRIPTION
Базовое поле ввода `ResideTrackTextField` использовало дефолтный Material-курсор (фиолетовый `colorScheme.primary`).

Проставил в дефолтные `colors`:
- `cursorColor` → `ResideTrackTheme.colors.textAccent`
- `errorCursorColor` → `ResideTrackTheme.colors.textError`

Так же, как в `ResideTrackDatePicker` и selection-цветах `Theme.kt`. Все поля на базе `ResideTrackTextField` (add-room, room-editor и т.д.) получают брендовый курсор разом.

Проверено на эмуляторе: курсор синий (textAccent), build + detekt зелёные.