### PR TITLE
fix(rooms): sort floors and rooms ascending

### DIFF
--- a/shared/feature-rooms/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/domain/RoomsExecutor.kt
+++ b/shared/feature-rooms/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/domain/RoomsExecutor.kt
@@ -1,5 +1,6 @@
 package dev.nonoxy.residetrack.feature.rooms.impl.domain
 
+import dev.nonoxy.residetrack.core.rooms.models.Room
 import dev.nonoxy.residetrack.core.rooms.repository.RoomsRepository
 import dev.nonoxy.residetrack.feature.rooms.api.store.RoomsStore.Intent
 import dev.nonoxy.residetrack.feature.rooms.api.store.RoomsStore.Label
@@ -36,7 +37,11 @@ internal class RoomsExecutor(
         roomsRepository.observeRooms()
             .catch { dispatch(Message.SetError) }
             .collect { rooms ->
-                val grouped = rooms.groupBy { room -> room.floorNumber }
+                // DB query returns rooms unordered (no ORDER BY); sort here so floors
+                // page in ascending order and rooms read top-down within a floor.
+                val grouped = rooms
+                    .sortedWith(compareBy(Room::floorNumber, Room::roomNumber))
+                    .groupBy { room -> room.floorNumber }
                 dispatch(Message.SetRoomsOnFloor(roomsOnFloor = grouped))
             }
     }

--- a/shared/feature-rooms/impl/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/domain/RoomsExecutorTest.kt
+++ b/shared/feature-rooms/impl/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/domain/RoomsExecutorTest.kt
@@ -55,6 +55,26 @@ class RoomsExecutorTest {
     }
 
     @Test
+    fun `LoadInitial sorts floors ascending and rooms by number within a floor`() = runTest {
+        val repository = FakeRoomsRepository(
+            rooms = listOf(
+                room(id = 1, floor = 3, number = 32),
+                room(id = 2, floor = 1, number = 12),
+                room(id = 3, floor = 1, number = 11),
+                room(id = 4, floor = 2, number = 21),
+            ),
+        )
+
+        val store = createStore(repository)
+
+        val state = store.state
+        assertEquals(listOf(1, 2, 3), state.roomsOnFloor.keys.toList())
+        assertEquals(listOf(11, 12), state.roomsOnFloor.getValue(1).map { room -> room.roomNumber })
+
+        store.dispose()
+    }
+
+    @Test
     fun `observeRooms failure sets error and clears loading`() = runTest {
         val repository = FakeRoomsRepository().apply { observeRoomsError = RuntimeException("boom") }
 


### PR DESCRIPTION
Список комнат группировался через `groupBy { floorNumber }` поверх DAO-запроса без `ORDER BY` — этажи в pager и комнаты внутри этажа шли в порядке rowid, не по возрастанию.

Сортировка вынесена в `RoomsExecutor` (`compareBy(floorNumber, roomNumber)` перед группировкой) — единая точка истины, presentation-маппер порядок сохраняет.

Покрыто тестом `RoomsExecutorTest`: этажи по возрастанию, комнаты внутри этажа по номеру.