### PR TITLE
feat: резервная копия БД — экспорт/импорт (replace-all) + рефактор core-rooms

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -44,6 +44,7 @@ include(
     ":shared:core-database",
     ":shared:core-initializer",
     ":shared:core-rooms",
+    ":shared:core-backup",
     ":shared:common-ui",
 
     // Features

--- a/shared/common-resources/src/commonMain/moko-resources/base/plurals.xml
+++ b/shared/common-resources/src/commonMain/moko-resources/base/plurals.xml
@@ -12,4 +12,16 @@
         <item quantity="many">Свободно %1$d мест</item>
         <item quantity="other">Свободно %1$d мест</item>
     </plurals>
+    <plurals name="backup_rooms_count">
+        <item quantity="one">%1$d комната</item>
+        <item quantity="few">%1$d комнаты</item>
+        <item quantity="many">%1$d комнат</item>
+        <item quantity="other">%1$d комнат</item>
+    </plurals>
+    <plurals name="backup_students_count">
+        <item quantity="one">%1$d жилец</item>
+        <item quantity="few">%1$d жильца</item>
+        <item quantity="many">%1$d жильцов</item>
+        <item quantity="other">%1$d жильцов</item>
+    </plurals>
 </resources>

--- a/shared/common-resources/src/commonMain/moko-resources/base/strings.xml
+++ b/shared/common-resources/src/commonMain/moko-resources/base/strings.xml
@@ -132,7 +132,9 @@
     <string name="backup_import_confirm">Восстановить</string>
     <string name="backup_cancel">Отменить</string>
     <string name="backup_export_success">Резервная копия создана</string>
+    <string name="backup_export_empty">Нет данных для резервной копии</string>
     <string name="backup_export_error">Не удалось создать резервную копию</string>
+    <string name="backup_import_empty">Файл не содержит данных для восстановления</string>
     <string name="backup_import_success">Данные восстановлены</string>
     <string name="backup_import_error">Не удалось прочитать файл</string>
     <string name="backup_restore_error">Не удалось восстановить данные</string>

--- a/shared/common-resources/src/commonMain/moko-resources/base/strings.xml
+++ b/shared/common-resources/src/commonMain/moko-resources/base/strings.xml
@@ -128,7 +128,8 @@
     <string name="backup_menu_content_description">Меню резервной копии</string>
     <string name="backup_import_dialog_title">Восстановить из копии?</string>
     <string name="backup_import_dialog_message">Все текущие комнаты и жильцы будут заменены данными из файла. Действие необратимо.</string>
-    <string name="backup_import_dialog_counts">Найдено: комнат — %1$d, жильцов — %2$d</string>
+    <string name="backup_import_current">Сейчас: %1$s, %2$s</string>
+    <string name="backup_import_after">Станет: %1$s, %2$s</string>
     <string name="backup_import_confirm">Восстановить</string>
     <string name="backup_cancel">Отменить</string>
     <string name="backup_export_success">Резервная копия создана</string>

--- a/shared/common-resources/src/commonMain/moko-resources/base/strings.xml
+++ b/shared/common-resources/src/commonMain/moko-resources/base/strings.xml
@@ -121,4 +121,19 @@
     <string name="error_failed_to_delete_room">Не удалось удалить комнату</string>
     <string name="room_updated_successfully">Параметры комнаты обновлены</string>
     <string name="room_deleted_successfully">Комната удалена</string>
+
+    <!-- Backup: export/import -->
+    <string name="backup_menu_export">Создать резервную копию</string>
+    <string name="backup_menu_import">Восстановить из копии</string>
+    <string name="backup_menu_content_description">Меню резервной копии</string>
+    <string name="backup_import_dialog_title">Восстановить из копии?</string>
+    <string name="backup_import_dialog_message">Все текущие комнаты и жильцы будут заменены данными из файла. Действие необратимо.</string>
+    <string name="backup_import_dialog_counts">Найдено: комнат — %1$d, жильцов — %2$d</string>
+    <string name="backup_import_confirm">Восстановить</string>
+    <string name="backup_cancel">Отменить</string>
+    <string name="backup_export_success">Резервная копия создана</string>
+    <string name="backup_export_error">Не удалось создать резервную копию</string>
+    <string name="backup_import_success">Данные восстановлены</string>
+    <string name="backup_import_error">Не удалось прочитать файл</string>
+    <string name="backup_restore_error">Не удалось восстановить данные</string>
 </resources>

--- a/shared/common-resources/src/commonMain/moko-resources/base/strings.xml
+++ b/shared/common-resources/src/commonMain/moko-resources/base/strings.xml
@@ -137,6 +137,7 @@
     <string name="backup_export_error">Не удалось создать резервную копию</string>
     <string name="backup_import_empty">Файл не содержит данных для восстановления</string>
     <string name="backup_import_success">Данные восстановлены</string>
-    <string name="backup_import_error">Не удалось прочитать файл</string>
+    <string name="backup_import_error">Не похоже на файл резервной копии</string>
+    <string name="backup_import_error_version">Версия резервной копии не поддерживается</string>
     <string name="backup_restore_error">Не удалось восстановить данные</string>
 </resources>

--- a/shared/common-resources/src/commonMain/moko-resources/images/ic_backup_export.svg
+++ b/shared/common-resources/src/commonMain/moko-resources/images/ic_backup_export.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+  <path d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z" fill="#000000"/>
+</svg>

--- a/shared/common-resources/src/commonMain/moko-resources/images/ic_backup_restore.svg
+++ b/shared/common-resources/src/commonMain/moko-resources/images/ic_backup_restore.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+  <path d="M9 16h6v-6h4l-7-7-7 7h4v6zm-4 2h14v2H5v-2z" fill="#000000"/>
+</svg>

--- a/shared/common-resources/src/commonMain/moko-resources/images/ic_more.svg
+++ b/shared/common-resources/src/commonMain/moko-resources/images/ic_more.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+  <circle cx="12" cy="5" r="2" fill="#000000"/>
+  <circle cx="12" cy="12" r="2" fill="#000000"/>
+  <circle cx="12" cy="19" r="2" fill="#000000"/>
+</svg>

--- a/shared/core-backup/build.gradle.kts
+++ b/shared/core-backup/build.gradle.kts
@@ -1,0 +1,29 @@
+import extensions.androidLibraryConfig
+import extensions.commonMainDependencies
+import extensions.commonTestDependencies
+import extensions.implementations
+
+plugins {
+    alias(libs.plugins.conventionPlugin.kmpLibrary)
+    alias(libs.plugins.conventionPlugin.jsonSerialization)
+}
+
+androidLibraryConfig {
+    namespace = "dev.nonoxy.residetrack.core.backup"
+}
+
+commonMainDependencies {
+    implementations(
+        projects.shared.common,
+        projects.shared.coreDatabase,
+        libs.kotlin.serialization.json,
+        libs.kotlin.coroutines.core,
+    )
+}
+
+commonTestDependencies {
+    implementations(
+        libs.kotlin.test,
+        libs.kotlin.coroutines.test,
+    )
+}

--- a/shared/core-backup/src/commonMain/kotlin/dev/nonoxy/residetrack/core/backup/data/BackupRepositoryImpl.kt
+++ b/shared/core-backup/src/commonMain/kotlin/dev/nonoxy/residetrack/core/backup/data/BackupRepositoryImpl.kt
@@ -7,6 +7,8 @@ import dev.nonoxy.residetrack.core.backup.data.model.BACKUP_FORMAT_VERSION
 import dev.nonoxy.residetrack.core.backup.data.model.BackupFileDto
 import dev.nonoxy.residetrack.core.backup.domain.model.Backup
 import dev.nonoxy.residetrack.core.backup.domain.repository.BackupRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import kotlin.time.Clock
 
@@ -15,21 +17,27 @@ internal class BackupRepositoryImpl(
     private val json: Json,
 ) : BackupRepository {
 
+    // Serialization is CPU-bound and can be heavy for a large dorm; keep it off the caller's
+    // dispatcher. The gateway's Room access already confines its own DB threading.
     override suspend fun export(): Result<String> = runCatching {
-        val dto = BackupFileDto(
-            version = BACKUP_FORMAT_VERSION,
-            exportedAtEpochMillis = Clock.System.now().toEpochMilliseconds(),
-            rooms = gateway.loadAll().toRoomDtos(),
-        )
-        json.encodeToString(dto)
+        withContext(Dispatchers.Default) {
+            val dto = BackupFileDto(
+                version = BACKUP_FORMAT_VERSION,
+                exportedAtEpochMillis = Clock.System.now().toEpochMilliseconds(),
+                rooms = gateway.loadAll().toRoomDtos(),
+            )
+            json.encodeToString(dto)
+        }
     }
 
     override suspend fun parse(rawJson: String): Result<Backup> = runCatching {
-        val dto = json.decodeFromString<BackupFileDto>(rawJson)
-        require(dto.version == BACKUP_FORMAT_VERSION) {
-            "Unsupported backup version: ${dto.version}"
+        withContext(Dispatchers.Default) {
+            val dto = json.decodeFromString<BackupFileDto>(rawJson)
+            require(dto.version == BACKUP_FORMAT_VERSION) {
+                "Unsupported backup version: ${dto.version}"
+            }
+            dto.rooms.toDomain()
         }
-        dto.rooms.toDomain()
     }
 
     override suspend fun restore(backup: Backup): Result<Unit> = runCatching {

--- a/shared/core-backup/src/commonMain/kotlin/dev/nonoxy/residetrack/core/backup/data/BackupRepositoryImpl.kt
+++ b/shared/core-backup/src/commonMain/kotlin/dev/nonoxy/residetrack/core/backup/data/BackupRepositoryImpl.kt
@@ -6,6 +6,7 @@ import dev.nonoxy.residetrack.core.backup.data.mapper.toRoomDtos
 import dev.nonoxy.residetrack.core.backup.data.model.BACKUP_FORMAT_VERSION
 import dev.nonoxy.residetrack.core.backup.data.model.BackupFileDto
 import dev.nonoxy.residetrack.core.backup.domain.model.Backup
+import dev.nonoxy.residetrack.core.backup.domain.model.UnsupportedBackupVersionException
 import dev.nonoxy.residetrack.core.backup.domain.repository.BackupRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -33,8 +34,8 @@ internal class BackupRepositoryImpl(
     override suspend fun parse(rawJson: String): Result<Backup> = runCatching {
         withContext(Dispatchers.Default) {
             val dto = json.decodeFromString<BackupFileDto>(rawJson)
-            require(dto.version == BACKUP_FORMAT_VERSION) {
-                "Unsupported backup version: ${dto.version}"
+            if (dto.version != BACKUP_FORMAT_VERSION) {
+                throw UnsupportedBackupVersionException(dto.version)
             }
             dto.rooms.toDomain()
         }

--- a/shared/core-backup/src/commonMain/kotlin/dev/nonoxy/residetrack/core/backup/data/BackupRepositoryImpl.kt
+++ b/shared/core-backup/src/commonMain/kotlin/dev/nonoxy/residetrack/core/backup/data/BackupRepositoryImpl.kt
@@ -1,0 +1,38 @@
+package dev.nonoxy.residetrack.core.backup.data
+
+import dev.nonoxy.residetrack.core.backup.data.gateway.BackupGateway
+import dev.nonoxy.residetrack.core.backup.data.mapper.toDomain
+import dev.nonoxy.residetrack.core.backup.data.mapper.toRoomDtos
+import dev.nonoxy.residetrack.core.backup.data.model.BACKUP_FORMAT_VERSION
+import dev.nonoxy.residetrack.core.backup.data.model.BackupFileDto
+import dev.nonoxy.residetrack.core.backup.domain.model.Backup
+import dev.nonoxy.residetrack.core.backup.domain.repository.BackupRepository
+import kotlinx.serialization.json.Json
+import kotlin.time.Clock
+
+internal class BackupRepositoryImpl(
+    private val gateway: BackupGateway,
+    private val json: Json,
+) : BackupRepository {
+
+    override suspend fun export(): Result<String> = runCatching {
+        val dto = BackupFileDto(
+            version = BACKUP_FORMAT_VERSION,
+            exportedAtEpochMillis = Clock.System.now().toEpochMilliseconds(),
+            rooms = gateway.loadAll().toRoomDtos(),
+        )
+        json.encodeToString(dto)
+    }
+
+    override suspend fun parse(rawJson: String): Result<Backup> = runCatching {
+        val dto = json.decodeFromString<BackupFileDto>(rawJson)
+        require(dto.version == BACKUP_FORMAT_VERSION) {
+            "Unsupported backup version: ${dto.version}"
+        }
+        dto.rooms.toDomain()
+    }
+
+    override suspend fun restore(backup: Backup): Result<Unit> = runCatching {
+        gateway.replaceAll(backup)
+    }
+}

--- a/shared/core-backup/src/commonMain/kotlin/dev/nonoxy/residetrack/core/backup/data/gateway/BackupGateway.kt
+++ b/shared/core-backup/src/commonMain/kotlin/dev/nonoxy/residetrack/core/backup/data/gateway/BackupGateway.kt
@@ -1,0 +1,15 @@
+package dev.nonoxy.residetrack.core.backup.data.gateway
+
+import dev.nonoxy.residetrack.core.backup.domain.model.Backup
+
+/**
+ * Persistence port for backup, speaking domain [Backup] only. Exists so [BackupRepositoryImpl]
+ * stays free of Room types and is unit-testable with a fake — the concrete [RoomBackupGateway]
+ * wraps the DAO and owns the entity↔domain mapping.
+ */
+internal interface BackupGateway {
+
+    suspend fun loadAll(): Backup
+
+    suspend fun replaceAll(backup: Backup)
+}

--- a/shared/core-backup/src/commonMain/kotlin/dev/nonoxy/residetrack/core/backup/data/gateway/RoomBackupGateway.kt
+++ b/shared/core-backup/src/commonMain/kotlin/dev/nonoxy/residetrack/core/backup/data/gateway/RoomBackupGateway.kt
@@ -1,0 +1,51 @@
+package dev.nonoxy.residetrack.core.backup.data.gateway
+
+import dev.nonoxy.residetrack.core.backup.domain.model.Backup
+import dev.nonoxy.residetrack.core.backup.domain.model.BackupRoom
+import dev.nonoxy.residetrack.core.backup.domain.model.BackupStudent
+import dev.nonoxy.residetrack.core.database.dao.RoomDao
+import dev.nonoxy.residetrack.core.database.entities.RoomEntity
+import dev.nonoxy.residetrack.core.database.entities.StudentEntity
+import dev.nonoxy.residetrack.core.database.relations.RoomWithStudents
+
+internal class RoomBackupGateway(
+    private val roomDao: RoomDao,
+) : BackupGateway {
+
+    override suspend fun loadAll(): Backup =
+        Backup(rooms = roomDao.getAllRoomsWithStudents().map { it.toBackupRoom() })
+
+    override suspend fun replaceAll(backup: Backup) {
+        val rooms = backup.rooms.map { room ->
+            RoomEntity(
+                floorNumber = room.floorNumber,
+                roomNumber = room.roomNumber,
+                bedsCount = room.bedsCount,
+            )
+        }
+        val studentsByRoom = backup.rooms.map { room ->
+            room.students.map { student ->
+                StudentEntity(
+                    roomId = 0,
+                    streamNumber = student.streamNumber,
+                    checkInDateEpochMillis = student.checkInEpochMillis,
+                    checkOutDateEpochMillis = student.checkOutEpochMillis,
+                )
+            }
+        }
+        roomDao.replaceAllRoomsWithStudents(rooms = rooms, studentsByRoom = studentsByRoom)
+    }
+}
+
+private fun RoomWithStudents.toBackupRoom(): BackupRoom = BackupRoom(
+    floorNumber = room.floorNumber,
+    roomNumber = room.roomNumber,
+    bedsCount = room.bedsCount,
+    students = students.map { entity ->
+        BackupStudent(
+            streamNumber = entity.streamNumber,
+            checkInEpochMillis = entity.checkInDateEpochMillis,
+            checkOutEpochMillis = entity.checkOutDateEpochMillis,
+        )
+    },
+)

--- a/shared/core-backup/src/commonMain/kotlin/dev/nonoxy/residetrack/core/backup/data/mapper/BackupDtoMapper.kt
+++ b/shared/core-backup/src/commonMain/kotlin/dev/nonoxy/residetrack/core/backup/data/mapper/BackupDtoMapper.kt
@@ -1,0 +1,37 @@
+package dev.nonoxy.residetrack.core.backup.data.mapper
+
+import dev.nonoxy.residetrack.core.backup.data.model.BackupRoomDto
+import dev.nonoxy.residetrack.core.backup.data.model.BackupStudentDto
+import dev.nonoxy.residetrack.core.backup.domain.model.Backup
+import dev.nonoxy.residetrack.core.backup.domain.model.BackupRoom
+import dev.nonoxy.residetrack.core.backup.domain.model.BackupStudent
+
+internal fun Backup.toRoomDtos(): List<BackupRoomDto> = rooms.map { room -> room.toDto() }
+
+internal fun List<BackupRoomDto>.toDomain(): Backup = Backup(rooms = map { dto -> dto.toDomain() })
+
+private fun BackupRoom.toDto(): BackupRoomDto = BackupRoomDto(
+    floorNumber = floorNumber,
+    roomNumber = roomNumber,
+    bedsCount = bedsCount,
+    students = students.map { student -> student.toDto() },
+)
+
+private fun BackupStudent.toDto(): BackupStudentDto = BackupStudentDto(
+    streamNumber = streamNumber,
+    checkInEpochMillis = checkInEpochMillis,
+    checkOutEpochMillis = checkOutEpochMillis,
+)
+
+private fun BackupRoomDto.toDomain(): BackupRoom = BackupRoom(
+    floorNumber = floorNumber,
+    roomNumber = roomNumber,
+    bedsCount = bedsCount,
+    students = students.map { dto -> dto.toDomain() },
+)
+
+private fun BackupStudentDto.toDomain(): BackupStudent = BackupStudent(
+    streamNumber = streamNumber,
+    checkInEpochMillis = checkInEpochMillis,
+    checkOutEpochMillis = checkOutEpochMillis,
+)

--- a/shared/core-backup/src/commonMain/kotlin/dev/nonoxy/residetrack/core/backup/data/model/BackupFileDto.kt
+++ b/shared/core-backup/src/commonMain/kotlin/dev/nonoxy/residetrack/core/backup/data/model/BackupFileDto.kt
@@ -1,0 +1,34 @@
+package dev.nonoxy.residetrack.core.backup.data.model
+
+import kotlinx.serialization.Serializable
+
+/** Current backup file format version. Bumped whenever the on-disk schema changes. */
+internal const val BACKUP_FORMAT_VERSION = 1
+
+/**
+ * On-disk JSON shape of a backup. Lives in the data layer and never crosses the repository
+ * boundary — [version]/[exportedAtEpochMillis] are file concerns the domain must not know about.
+ * Room/student ids are intentionally absent: restore is replace-all, ids are regenerated and the
+ * room↔student link is carried by nesting.
+ */
+@Serializable
+internal data class BackupFileDto(
+    val version: Int,
+    val exportedAtEpochMillis: Long,
+    val rooms: List<BackupRoomDto>,
+)
+
+@Serializable
+internal data class BackupRoomDto(
+    val floorNumber: Int,
+    val roomNumber: Int,
+    val bedsCount: Int,
+    val students: List<BackupStudentDto>,
+)
+
+@Serializable
+internal data class BackupStudentDto(
+    val streamNumber: Int,
+    val checkInEpochMillis: Long,
+    val checkOutEpochMillis: Long,
+)

--- a/shared/core-backup/src/commonMain/kotlin/dev/nonoxy/residetrack/core/backup/di/CoreBackupModule.kt
+++ b/shared/core-backup/src/commonMain/kotlin/dev/nonoxy/residetrack/core/backup/di/CoreBackupModule.kt
@@ -1,0 +1,12 @@
+package dev.nonoxy.residetrack.core.backup.di
+
+import dev.nonoxy.residetrack.core.backup.data.BackupRepositoryImpl
+import dev.nonoxy.residetrack.core.backup.data.gateway.BackupGateway
+import dev.nonoxy.residetrack.core.backup.data.gateway.RoomBackupGateway
+import dev.nonoxy.residetrack.core.backup.domain.repository.BackupRepository
+import org.koin.dsl.module
+
+val coreBackupModule = module {
+    single<BackupGateway> { RoomBackupGateway(roomDao = get()) }
+    single<BackupRepository> { BackupRepositoryImpl(gateway = get(), json = get()) }
+}

--- a/shared/core-backup/src/commonMain/kotlin/dev/nonoxy/residetrack/core/backup/domain/model/Backup.kt
+++ b/shared/core-backup/src/commonMain/kotlin/dev/nonoxy/residetrack/core/backup/domain/model/Backup.kt
@@ -11,6 +11,7 @@ data class Backup(
 ) {
     val roomCount: Int get() = rooms.size
     val studentCount: Int get() = rooms.sumOf { room -> room.students.size }
+    val isEmpty: Boolean get() = rooms.isEmpty()
 }
 
 data class BackupRoom(

--- a/shared/core-backup/src/commonMain/kotlin/dev/nonoxy/residetrack/core/backup/domain/model/Backup.kt
+++ b/shared/core-backup/src/commonMain/kotlin/dev/nonoxy/residetrack/core/backup/domain/model/Backup.kt
@@ -1,0 +1,27 @@
+package dev.nonoxy.residetrack.core.backup.domain.model
+
+/**
+ * A backup snapshot of the whole database. This is its own bounded context — deliberately separate
+ * from the live `Room`/`Student` domain — so the backup format can evolve without dragging the
+ * rooms domain along. Dates stay as epoch millis (the persistence representation) because a backup
+ * is a raw dump, not a domain view.
+ */
+data class Backup(
+    val rooms: List<BackupRoom>,
+) {
+    val roomCount: Int get() = rooms.size
+    val studentCount: Int get() = rooms.sumOf { room -> room.students.size }
+}
+
+data class BackupRoom(
+    val floorNumber: Int,
+    val roomNumber: Int,
+    val bedsCount: Int,
+    val students: List<BackupStudent>,
+)
+
+data class BackupStudent(
+    val streamNumber: Int,
+    val checkInEpochMillis: Long,
+    val checkOutEpochMillis: Long,
+)

--- a/shared/core-backup/src/commonMain/kotlin/dev/nonoxy/residetrack/core/backup/domain/model/UnsupportedBackupVersionException.kt
+++ b/shared/core-backup/src/commonMain/kotlin/dev/nonoxy/residetrack/core/backup/domain/model/UnsupportedBackupVersionException.kt
@@ -1,0 +1,9 @@
+package dev.nonoxy.residetrack.core.backup.domain.model
+
+/**
+ * Thrown by parsing when a backup file is well-formed but its format version is not understood by
+ * this build. Distinct from a generic parse failure so the UI can tell "wrong/old backup" from
+ * "this isn't a backup file at all".
+ */
+class UnsupportedBackupVersionException(val version: Int) :
+    Exception("Unsupported backup version: $version")

--- a/shared/core-backup/src/commonMain/kotlin/dev/nonoxy/residetrack/core/backup/domain/model/UnsupportedBackupVersionException.kt
+++ b/shared/core-backup/src/commonMain/kotlin/dev/nonoxy/residetrack/core/backup/domain/model/UnsupportedBackupVersionException.kt
@@ -1,9 +1,5 @@
 package dev.nonoxy.residetrack.core.backup.domain.model
 
-/**
- * Thrown by parsing when a backup file is well-formed but its format version is not understood by
- * this build. Distinct from a generic parse failure so the UI can tell "wrong/old backup" from
- * "this isn't a backup file at all".
- */
+/** Distinct from a generic parse failure so the UI can tell "wrong/old backup" from "not a backup". */
 class UnsupportedBackupVersionException(val version: Int) :
     Exception("Unsupported backup version: $version")

--- a/shared/core-backup/src/commonMain/kotlin/dev/nonoxy/residetrack/core/backup/domain/repository/BackupRepository.kt
+++ b/shared/core-backup/src/commonMain/kotlin/dev/nonoxy/residetrack/core/backup/domain/repository/BackupRepository.kt
@@ -1,0 +1,24 @@
+package dev.nonoxy.residetrack.core.backup.domain.repository
+
+import dev.nonoxy.residetrack.core.backup.domain.model.Backup
+
+/**
+ * Export/import of the whole database as a portable JSON backup. Only domain types cross this
+ * boundary — the on-disk file format ([dev.nonoxy.residetrack.core.backup.data.model] DTOs) never
+ * leaks out. Import is a two-step: [parse] validates a picked file (no DB writes) so the caller can
+ * confirm with the user, then [restore] replaces everything atomically.
+ */
+interface BackupRepository {
+
+    /** Reads the current database into a JSON string ready to be written to a user-picked file. */
+    suspend fun export(): Result<String>
+
+    /**
+     * Parses and validates [rawJson] from a picked file into a [Backup] without touching the
+     * database. Fails on malformed JSON or an incompatible format version.
+     */
+    suspend fun parse(rawJson: String): Result<Backup>
+
+    /** Replaces the entire database with [backup] atomically (rolls back on failure). */
+    suspend fun restore(backup: Backup): Result<Unit>
+}

--- a/shared/core-backup/src/commonTest/kotlin/dev/nonoxy/residetrack/core/backup/data/BackupRepositoryImplTest.kt
+++ b/shared/core-backup/src/commonTest/kotlin/dev/nonoxy/residetrack/core/backup/data/BackupRepositoryImplTest.kt
@@ -1,0 +1,107 @@
+package dev.nonoxy.residetrack.core.backup.data
+
+import dev.nonoxy.residetrack.core.backup.domain.model.Backup
+import dev.nonoxy.residetrack.core.backup.domain.model.BackupRoom
+import dev.nonoxy.residetrack.core.backup.domain.model.BackupStudent
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class BackupRepositoryImplTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private fun backup() = Backup(
+        rooms = listOf(
+            BackupRoom(
+                floorNumber = 3,
+                roomNumber = 329,
+                bedsCount = 5,
+                students = listOf(
+                    BackupStudent(streamNumber = 12, checkInEpochMillis = 1000L, checkOutEpochMillis = 2000L),
+                    BackupStudent(streamNumber = 13, checkInEpochMillis = 3000L, checkOutEpochMillis = 4000L),
+                ),
+            ),
+            BackupRoom(floorNumber = 4, roomNumber = 401, bedsCount = 2, students = emptyList()),
+        ),
+    )
+
+    private fun repository(gateway: FakeBackupGateway) = BackupRepositoryImpl(gateway = gateway, json = json)
+
+    @Test
+    fun `export then parse round-trips the backup`() = runTest {
+        val source = backup()
+        val repository = repository(FakeBackupGateway(stored = source))
+
+        val exported = repository.export()
+        assertTrue(exported.isSuccess)
+
+        val parsed = repository.parse(exported.getOrThrow())
+        assertEquals(source, parsed.getOrThrow())
+    }
+
+    @Test
+    fun `exported json carries the current format version`() = runTest {
+        val repository = repository(FakeBackupGateway(stored = backup()))
+
+        val raw = repository.export().getOrThrow()
+
+        assertTrue(raw.contains("\"version\":1"), "export must stamp version=1, was: $raw")
+    }
+
+    @Test
+    fun `parse computes room and student counts`() = runTest {
+        val repository = repository(FakeBackupGateway(stored = backup()))
+        val raw = repository.export().getOrThrow()
+
+        val parsed = repository.parse(raw).getOrThrow()
+
+        assertEquals(2, parsed.roomCount)
+        assertEquals(2, parsed.studentCount)
+    }
+
+    @Test
+    fun `parse malformed json fails without throwing`() = runTest {
+        val repository = repository(FakeBackupGateway())
+
+        val result = repository.parse("{ not valid json")
+
+        assertTrue(result.isFailure)
+    }
+
+    @Test
+    fun `parse rejects an incompatible format version`() = runTest {
+        val repository = repository(FakeBackupGateway())
+        val futureFile = """{"version":999,"exportedAtEpochMillis":0,"rooms":[]}"""
+
+        val result = repository.parse(futureFile)
+
+        assertTrue(result.isFailure)
+    }
+
+    @Test
+    fun `restore hands the backup to the gateway`() = runTest {
+        val gateway = FakeBackupGateway()
+        val repository = repository(gateway)
+        val source = backup()
+
+        val result = repository.restore(source)
+
+        assertTrue(result.isSuccess)
+        assertEquals(source, gateway.restoredWith)
+    }
+
+    @Test
+    fun `restore is not triggered by parse`() = runTest {
+        val gateway = FakeBackupGateway()
+        val repository = repository(gateway)
+        val raw = repository(FakeBackupGateway(stored = backup())).export().getOrThrow()
+
+        repository.parse(raw)
+
+        assertNull(gateway.restoredWith)
+    }
+}

--- a/shared/core-backup/src/commonTest/kotlin/dev/nonoxy/residetrack/core/backup/data/BackupRepositoryImplTest.kt
+++ b/shared/core-backup/src/commonTest/kotlin/dev/nonoxy/residetrack/core/backup/data/BackupRepositoryImplTest.kt
@@ -3,6 +3,7 @@ package dev.nonoxy.residetrack.core.backup.data
 import dev.nonoxy.residetrack.core.backup.domain.model.Backup
 import dev.nonoxy.residetrack.core.backup.domain.model.BackupRoom
 import dev.nonoxy.residetrack.core.backup.domain.model.BackupStudent
+import dev.nonoxy.residetrack.core.backup.domain.model.UnsupportedBackupVersionException
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import kotlin.test.Test
@@ -79,7 +80,9 @@ class BackupRepositoryImplTest {
 
         val result = repository.parse(futureFile)
 
-        assertTrue(result.isFailure)
+        val error = result.exceptionOrNull()
+        assertTrue(error is UnsupportedBackupVersionException)
+        assertEquals(999, error.version)
     }
 
     @Test

--- a/shared/core-backup/src/commonTest/kotlin/dev/nonoxy/residetrack/core/backup/data/FakeBackupGateway.kt
+++ b/shared/core-backup/src/commonTest/kotlin/dev/nonoxy/residetrack/core/backup/data/FakeBackupGateway.kt
@@ -1,0 +1,18 @@
+package dev.nonoxy.residetrack.core.backup.data
+
+import dev.nonoxy.residetrack.core.backup.data.gateway.BackupGateway
+import dev.nonoxy.residetrack.core.backup.domain.model.Backup
+
+internal class FakeBackupGateway(
+    private val stored: Backup = Backup(rooms = emptyList()),
+) : BackupGateway {
+
+    var restoredWith: Backup? = null
+        private set
+
+    override suspend fun loadAll(): Backup = stored
+
+    override suspend fun replaceAll(backup: Backup) {
+        restoredWith = backup
+    }
+}

--- a/shared/core-database/src/commonMain/kotlin/dev/nonoxy/residetrack/core/database/dao/RoomDao.kt
+++ b/shared/core-database/src/commonMain/kotlin/dev/nonoxy/residetrack/core/database/dao/RoomDao.kt
@@ -112,6 +112,9 @@ abstract class RoomDao {
         rooms: List<RoomEntity>,
         studentsByRoom: List<List<StudentEntity>>,
     ) {
+        require(rooms.size == studentsByRoom.size) {
+            "rooms (${rooms.size}) and studentsByRoom (${studentsByRoom.size}) must be parallel lists"
+        }
         deleteAllRooms()
         rooms.forEachIndexed { index, room ->
             val roomId = insertRoom(room.copy(id = 0))

--- a/shared/core-database/src/commonMain/kotlin/dev/nonoxy/residetrack/core/database/dao/RoomDao.kt
+++ b/shared/core-database/src/commonMain/kotlin/dev/nonoxy/residetrack/core/database/dao/RoomDao.kt
@@ -52,6 +52,9 @@ abstract class RoomDao {
     @Query("DELETE FROM rooms WHERE id = :roomId")
     protected abstract suspend fun deleteRoomById(roomId: Long)
 
+    @Query("DELETE FROM rooms")
+    protected abstract suspend fun deleteAllRooms()
+
     @Query(
         "UPDATE rooms SET floorNumber = :floorNumber, roomNumber = :roomNumber, " +
             "bedsCount = :bedsCount WHERE id = :roomId"
@@ -96,5 +99,26 @@ abstract class RoomDao {
             insertStudents(students.map { it.copy(roomId = roomId) })
         }
         return roomId
+    }
+
+    /**
+     * Wipes every room (and, via CASCADE, every student) and re-inserts [rooms] with their students
+     * atomically — the restore half of backup import. Each entry in [studentsByRoom] holds the
+     * students for the room at the same index in [rooms]; ids are regenerated and each student's
+     * roomId is rewritten to its freshly inserted room, so the backup file never needs stable ids.
+     */
+    @Transaction
+    open suspend fun replaceAllRoomsWithStudents(
+        rooms: List<RoomEntity>,
+        studentsByRoom: List<List<StudentEntity>>,
+    ) {
+        deleteAllRooms()
+        rooms.forEachIndexed { index, room ->
+            val roomId = insertRoom(room.copy(id = 0))
+            val students = studentsByRoom[index]
+            if (students.isNotEmpty()) {
+                insertStudents(students.map { it.copy(id = 0, roomId = roomId) })
+            }
+        }
     }
 }

--- a/shared/core-rooms/src/commonMain/kotlin/dev/nonoxy/residetrack/core/rooms/data/RoomsRepositoryImpl.kt
+++ b/shared/core-rooms/src/commonMain/kotlin/dev/nonoxy/residetrack/core/rooms/data/RoomsRepositoryImpl.kt
@@ -9,8 +9,8 @@ import dev.nonoxy.residetrack.core.database.entities.RoomEntity
 import dev.nonoxy.residetrack.core.database.relations.RoomWithStudents
 import dev.nonoxy.residetrack.core.rooms.data.mappers.RoomMapper
 import dev.nonoxy.residetrack.core.rooms.data.mappers.StudentMapper
-import dev.nonoxy.residetrack.core.rooms.models.Room
-import dev.nonoxy.residetrack.core.rooms.repository.RoomsRepository
+import dev.nonoxy.residetrack.core.rooms.domain.model.Room
+import dev.nonoxy.residetrack.core.rooms.domain.repository.RoomsRepository
 import io.github.aakira.napier.Napier
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/shared/core-rooms/src/commonMain/kotlin/dev/nonoxy/residetrack/core/rooms/data/mappers/RoomMapper.kt
+++ b/shared/core-rooms/src/commonMain/kotlin/dev/nonoxy/residetrack/core/rooms/data/mappers/RoomMapper.kt
@@ -3,7 +3,7 @@ package dev.nonoxy.residetrack.core.rooms.data.mappers
 import dev.nonoxy.residetrack.common.utils.mapper.Mapper
 import dev.nonoxy.residetrack.core.database.entities.RoomEntity
 import dev.nonoxy.residetrack.core.database.relations.RoomWithStudents
-import dev.nonoxy.residetrack.core.rooms.models.Room
+import dev.nonoxy.residetrack.core.rooms.domain.model.Room
 
 internal interface RoomMapper : Mapper<RoomWithStudents, Room> {
     fun map(item: Room): RoomEntity

--- a/shared/core-rooms/src/commonMain/kotlin/dev/nonoxy/residetrack/core/rooms/data/mappers/StudentMapper.kt
+++ b/shared/core-rooms/src/commonMain/kotlin/dev/nonoxy/residetrack/core/rooms/data/mappers/StudentMapper.kt
@@ -3,8 +3,8 @@ package dev.nonoxy.residetrack.core.rooms.data.mappers
 import dev.nonoxy.residetrack.common.utils.mapper.Mapper
 import dev.nonoxy.residetrack.common.utils.toLocalDate
 import dev.nonoxy.residetrack.core.database.entities.StudentEntity
-import dev.nonoxy.residetrack.core.rooms.models.Student
-import dev.nonoxy.residetrack.core.rooms.upcoming.UpcomingCheckouts
+import dev.nonoxy.residetrack.core.rooms.domain.model.Student
+import dev.nonoxy.residetrack.core.rooms.domain.upcoming.UpcomingCheckouts
 import kotlin.time.Clock
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.atStartOfDayIn

--- a/shared/core-rooms/src/commonMain/kotlin/dev/nonoxy/residetrack/core/rooms/di/CoreRoomsModule.kt
+++ b/shared/core-rooms/src/commonMain/kotlin/dev/nonoxy/residetrack/core/rooms/di/CoreRoomsModule.kt
@@ -5,7 +5,7 @@ import dev.nonoxy.residetrack.core.rooms.data.mappers.RoomMapper
 import dev.nonoxy.residetrack.core.rooms.data.mappers.RoomMapperImpl
 import dev.nonoxy.residetrack.core.rooms.data.mappers.StudentMapper
 import dev.nonoxy.residetrack.core.rooms.data.mappers.StudentMapperImpl
-import dev.nonoxy.residetrack.core.rooms.repository.RoomsRepository
+import dev.nonoxy.residetrack.core.rooms.domain.repository.RoomsRepository
 import org.koin.core.module.dsl.factoryOf
 import org.koin.core.module.dsl.new
 import org.koin.dsl.module

--- a/shared/core-rooms/src/commonMain/kotlin/dev/nonoxy/residetrack/core/rooms/domain/model/Room.kt
+++ b/shared/core-rooms/src/commonMain/kotlin/dev/nonoxy/residetrack/core/rooms/domain/model/Room.kt
@@ -1,4 +1,4 @@
-package dev.nonoxy.residetrack.core.rooms.models
+package dev.nonoxy.residetrack.core.rooms.domain.model
 
 data class Room(
     val id: Long = 0,

--- a/shared/core-rooms/src/commonMain/kotlin/dev/nonoxy/residetrack/core/rooms/domain/model/Student.kt
+++ b/shared/core-rooms/src/commonMain/kotlin/dev/nonoxy/residetrack/core/rooms/domain/model/Student.kt
@@ -1,4 +1,4 @@
-package dev.nonoxy.residetrack.core.rooms.models
+package dev.nonoxy.residetrack.core.rooms.domain.model
 
 import kotlinx.datetime.LocalDate
 

--- a/shared/core-rooms/src/commonMain/kotlin/dev/nonoxy/residetrack/core/rooms/domain/repository/RoomsRepository.kt
+++ b/shared/core-rooms/src/commonMain/kotlin/dev/nonoxy/residetrack/core/rooms/domain/repository/RoomsRepository.kt
@@ -1,6 +1,6 @@
-package dev.nonoxy.residetrack.core.rooms.repository
+package dev.nonoxy.residetrack.core.rooms.domain.repository
 
-import dev.nonoxy.residetrack.core.rooms.models.Room
+import dev.nonoxy.residetrack.core.rooms.domain.model.Room
 import kotlinx.coroutines.flow.Flow
 
 interface RoomsRepository {

--- a/shared/core-rooms/src/commonMain/kotlin/dev/nonoxy/residetrack/core/rooms/domain/upcoming/UpcomingBucket.kt
+++ b/shared/core-rooms/src/commonMain/kotlin/dev/nonoxy/residetrack/core/rooms/domain/upcoming/UpcomingBucket.kt
@@ -1,3 +1,3 @@
-package dev.nonoxy.residetrack.core.rooms.upcoming
+package dev.nonoxy.residetrack.core.rooms.domain.upcoming
 
 enum class UpcomingBucket { OVERDUE, TODAY_TOMORROW, THIS_WEEK }

--- a/shared/core-rooms/src/commonMain/kotlin/dev/nonoxy/residetrack/core/rooms/domain/upcoming/UpcomingCheckouts.kt
+++ b/shared/core-rooms/src/commonMain/kotlin/dev/nonoxy/residetrack/core/rooms/domain/upcoming/UpcomingCheckouts.kt
@@ -1,4 +1,4 @@
-package dev.nonoxy.residetrack.core.rooms.upcoming
+package dev.nonoxy.residetrack.core.rooms.domain.upcoming
 
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.daysUntil

--- a/shared/core-rooms/src/commonMain/kotlin/dev/nonoxy/residetrack/core/rooms/domain/validation/RoomNumberConflict.kt
+++ b/shared/core-rooms/src/commonMain/kotlin/dev/nonoxy/residetrack/core/rooms/domain/validation/RoomNumberConflict.kt
@@ -1,6 +1,6 @@
-package dev.nonoxy.residetrack.core.rooms.validation
+package dev.nonoxy.residetrack.core.rooms.domain.validation
 
-import dev.nonoxy.residetrack.core.rooms.models.Room
+import dev.nonoxy.residetrack.core.rooms.domain.model.Room
 
 /** Single source of truth for "is this floor+room number already taken by another room". */
 object RoomNumberConflict {

--- a/shared/core-rooms/src/commonTest/kotlin/dev/nonoxy/residetrack/core/rooms/domain/upcoming/UpcomingCheckoutsTest.kt
+++ b/shared/core-rooms/src/commonTest/kotlin/dev/nonoxy/residetrack/core/rooms/domain/upcoming/UpcomingCheckoutsTest.kt
@@ -1,4 +1,4 @@
-package dev.nonoxy.residetrack.core.rooms.upcoming
+package dev.nonoxy.residetrack.core.rooms.domain.upcoming
 
 import kotlinx.datetime.LocalDate
 import kotlin.test.Test

--- a/shared/core-rooms/src/commonTest/kotlin/dev/nonoxy/residetrack/core/rooms/domain/validation/RoomNumberConflictTest.kt
+++ b/shared/core-rooms/src/commonTest/kotlin/dev/nonoxy/residetrack/core/rooms/domain/validation/RoomNumberConflictTest.kt
@@ -1,6 +1,6 @@
-package dev.nonoxy.residetrack.core.rooms.validation
+package dev.nonoxy.residetrack.core.rooms.domain.validation
 
-import dev.nonoxy.residetrack.core.rooms.models.Room
+import dev.nonoxy.residetrack.core.rooms.domain.model.Room
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue

--- a/shared/feature-add-room/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/add_room/impl/domain/AddRoomExecutor.kt
+++ b/shared/feature-add-room/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/add_room/impl/domain/AddRoomExecutor.kt
@@ -9,9 +9,9 @@ import dev.nonoxy.residetrack.feature.add_room.api.store.AddRoomSuccessKind
 import dev.nonoxy.residetrack.feature.add_room.impl.domain.AddRoomStoreFactory.Action
 import dev.nonoxy.residetrack.feature.add_room.impl.domain.AddRoomStoreFactory.AddRoomErrorKindOrNull
 import dev.nonoxy.residetrack.feature.add_room.impl.domain.AddRoomStoreFactory.Message
-import dev.nonoxy.residetrack.core.rooms.models.Room
-import dev.nonoxy.residetrack.core.rooms.repository.RoomsRepository
-import dev.nonoxy.residetrack.core.rooms.validation.RoomNumberConflict
+import dev.nonoxy.residetrack.core.rooms.domain.model.Room
+import dev.nonoxy.residetrack.core.rooms.domain.repository.RoomsRepository
+import dev.nonoxy.residetrack.core.rooms.domain.validation.RoomNumberConflict
 import dev.nonoxy.residetrack.core.mvikotlin.BaseExecutor
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.CoroutineDispatcher

--- a/shared/feature-add-room/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/add_room/impl/domain/AddRoomStoreFactory.kt
+++ b/shared/feature-add-room/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/add_room/impl/domain/AddRoomStoreFactory.kt
@@ -7,7 +7,7 @@ import dev.nonoxy.residetrack.feature.add_room.api.store.AddRoomStore
 import dev.nonoxy.residetrack.feature.add_room.api.store.AddRoomStore.Intent
 import dev.nonoxy.residetrack.feature.add_room.api.store.AddRoomStore.Label
 import dev.nonoxy.residetrack.feature.add_room.api.store.AddRoomStore.State
-import dev.nonoxy.residetrack.core.rooms.repository.RoomsRepository
+import dev.nonoxy.residetrack.core.rooms.domain.repository.RoomsRepository
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.CoroutineDispatcher
 

--- a/shared/feature-add-room/impl/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/add_room/impl/data/FakeRoomsRepository.kt
+++ b/shared/feature-add-room/impl/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/add_room/impl/data/FakeRoomsRepository.kt
@@ -1,7 +1,7 @@
 package dev.nonoxy.residetrack.feature.add_room.impl.data
 
-import dev.nonoxy.residetrack.core.rooms.models.Room
-import dev.nonoxy.residetrack.core.rooms.repository.RoomsRepository
+import dev.nonoxy.residetrack.core.rooms.domain.model.Room
+import dev.nonoxy.residetrack.core.rooms.domain.repository.RoomsRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flow

--- a/shared/feature-add-room/impl/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/add_room/impl/domain/AddRoomExecutorTest.kt
+++ b/shared/feature-add-room/impl/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/add_room/impl/domain/AddRoomExecutorTest.kt
@@ -2,7 +2,7 @@ package dev.nonoxy.residetrack.feature.add_room.impl.domain
 
 import com.arkivanov.mvikotlin.extensions.coroutines.labels
 import com.arkivanov.mvikotlin.main.store.DefaultStoreFactory
-import dev.nonoxy.residetrack.core.rooms.models.Room
+import dev.nonoxy.residetrack.core.rooms.domain.model.Room
 import dev.nonoxy.residetrack.feature.add_room.api.store.AddRoomErrorKind
 import dev.nonoxy.residetrack.feature.add_room.api.store.AddRoomStore
 import dev.nonoxy.residetrack.feature.add_room.api.store.AddRoomStore.Intent

--- a/shared/feature-room-editor/api/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/api/store/RoomEditorStore.kt
+++ b/shared/feature-room-editor/api/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/api/store/RoomEditorStore.kt
@@ -4,7 +4,7 @@ import com.arkivanov.mvikotlin.core.store.Store
 import dev.nonoxy.residetrack.feature.room_editor.api.store.RoomEditorStore.Intent
 import dev.nonoxy.residetrack.feature.room_editor.api.store.RoomEditorStore.Label
 import dev.nonoxy.residetrack.feature.room_editor.api.store.RoomEditorStore.State
-import dev.nonoxy.residetrack.core.rooms.models.Room
+import dev.nonoxy.residetrack.core.rooms.domain.model.Room
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 

--- a/shared/feature-room-editor/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/impl/domain/RoomEditorExecutor.kt
+++ b/shared/feature-room-editor/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/impl/domain/RoomEditorExecutor.kt
@@ -9,10 +9,10 @@ import dev.nonoxy.residetrack.feature.room_editor.api.store.RoomEditorStore.Stat
 import dev.nonoxy.residetrack.feature.room_editor.api.store.RoomEditorSuccessKind
 import dev.nonoxy.residetrack.feature.room_editor.impl.domain.RoomEditorStoreFactory.Action
 import dev.nonoxy.residetrack.feature.room_editor.impl.domain.RoomEditorStoreFactory.Message
-import dev.nonoxy.residetrack.core.rooms.models.Room
-import dev.nonoxy.residetrack.core.rooms.models.Student
-import dev.nonoxy.residetrack.core.rooms.repository.RoomsRepository
-import dev.nonoxy.residetrack.core.rooms.validation.RoomNumberConflict
+import dev.nonoxy.residetrack.core.rooms.domain.model.Room
+import dev.nonoxy.residetrack.core.rooms.domain.model.Student
+import dev.nonoxy.residetrack.core.rooms.domain.repository.RoomsRepository
+import dev.nonoxy.residetrack.core.rooms.domain.validation.RoomNumberConflict
 import dev.nonoxy.residetrack.core.mvikotlin.BaseExecutor
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CoroutineDispatcher

--- a/shared/feature-room-editor/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/impl/domain/RoomEditorStoreFactory.kt
+++ b/shared/feature-room-editor/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/impl/domain/RoomEditorStoreFactory.kt
@@ -9,8 +9,8 @@ import dev.nonoxy.residetrack.feature.room_editor.api.store.RoomEditorStore
 import dev.nonoxy.residetrack.feature.room_editor.api.store.RoomEditorStore.Intent
 import dev.nonoxy.residetrack.feature.room_editor.api.store.RoomEditorStore.Label
 import dev.nonoxy.residetrack.feature.room_editor.api.store.RoomEditorStore.State
-import dev.nonoxy.residetrack.core.rooms.models.Room
-import dev.nonoxy.residetrack.core.rooms.repository.RoomsRepository
+import dev.nonoxy.residetrack.core.rooms.domain.model.Room
+import dev.nonoxy.residetrack.core.rooms.domain.repository.RoomsRepository
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.CoroutineDispatcher
 

--- a/shared/feature-room-editor/impl/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/room_editor/impl/data/FakeRoomsRepository.kt
+++ b/shared/feature-room-editor/impl/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/room_editor/impl/data/FakeRoomsRepository.kt
@@ -1,7 +1,7 @@
 package dev.nonoxy.residetrack.feature.room_editor.impl.data
 
-import dev.nonoxy.residetrack.core.rooms.models.Room
-import dev.nonoxy.residetrack.core.rooms.repository.RoomsRepository
+import dev.nonoxy.residetrack.core.rooms.domain.model.Room
+import dev.nonoxy.residetrack.core.rooms.domain.repository.RoomsRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flow

--- a/shared/feature-room-editor/impl/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/room_editor/impl/domain/RoomEditorExecutorTest.kt
+++ b/shared/feature-room-editor/impl/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/room_editor/impl/domain/RoomEditorExecutorTest.kt
@@ -2,8 +2,8 @@ package dev.nonoxy.residetrack.feature.room_editor.impl.domain
 
 import com.arkivanov.mvikotlin.extensions.coroutines.labels
 import com.arkivanov.mvikotlin.main.store.DefaultStoreFactory
-import dev.nonoxy.residetrack.core.rooms.models.Room
-import dev.nonoxy.residetrack.core.rooms.models.Student
+import dev.nonoxy.residetrack.core.rooms.domain.model.Room
+import dev.nonoxy.residetrack.core.rooms.domain.model.Student
 import dev.nonoxy.residetrack.feature.room_editor.api.models.RoomEditorMode
 import dev.nonoxy.residetrack.feature.room_editor.api.store.RoomEditorErrorKind
 import dev.nonoxy.residetrack.feature.room_editor.api.store.RoomEditorStore

--- a/shared/feature-room-editor/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/presentation/mappers/UiRoomMapper.kt
+++ b/shared/feature-room-editor/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/presentation/mappers/UiRoomMapper.kt
@@ -2,7 +2,7 @@ package dev.nonoxy.residetrack.feature.room_editor.presentation.mappers
 
 import dev.nonoxy.residetrack.common.utils.mapper.Mapper
 import dev.nonoxy.residetrack.feature.room_editor.presentation.models.UiRoom
-import dev.nonoxy.residetrack.core.rooms.models.Room
+import dev.nonoxy.residetrack.core.rooms.domain.model.Room
 
 interface UiRoomMapper : Mapper<Room, UiRoom>
 

--- a/shared/feature-room-editor/presentation/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/room_editor/presentation/mappers/UiRoomEditorStateMapperTest.kt
+++ b/shared/feature-room-editor/presentation/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/room_editor/presentation/mappers/UiRoomEditorStateMapperTest.kt
@@ -1,6 +1,6 @@
 package dev.nonoxy.residetrack.feature.room_editor.presentation.mappers
 
-import dev.nonoxy.residetrack.core.rooms.models.Room
+import dev.nonoxy.residetrack.core.rooms.domain.model.Room
 import dev.nonoxy.residetrack.feature.room_editor.api.store.RoomEditorErrorKind
 import dev.nonoxy.residetrack.feature.room_editor.api.store.RoomEditorStore
 import dev.nonoxy.residetrack.feature.room_editor.api.store.RoomEditorStore.DateField

--- a/shared/feature-rooms/api/build.gradle.kts
+++ b/shared/feature-rooms/api/build.gradle.kts
@@ -13,5 +13,6 @@ androidLibraryConfig {
 commonMainDependencies {
     apis(
         projects.shared.coreRooms,
+        projects.shared.coreBackup,
     )
 }

--- a/shared/feature-rooms/api/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/api/store/BackupErrorKind.kt
+++ b/shared/feature-rooms/api/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/api/store/BackupErrorKind.kt
@@ -9,6 +9,9 @@ enum class BackupErrorKind {
     /** The picked file could not be read or parsed as a backup. */
     ImportReadFailed,
 
+    /** The picked file is a backup, but its format version is not supported by this build. */
+    ImportVersionUnsupported,
+
     /** The picked file parsed but holds no rooms, so restoring would only wipe existing data. */
     ImportEmpty,
     RestoreFailed,

--- a/shared/feature-rooms/api/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/api/store/BackupErrorKind.kt
+++ b/shared/feature-rooms/api/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/api/store/BackupErrorKind.kt
@@ -1,18 +1,10 @@
 package dev.nonoxy.residetrack.feature.rooms.api.store
 
-/** Why a backup operation failed (or was refused) — the UI resolves each to its own message. */
 enum class BackupErrorKind {
-    /** Export was refused because there is nothing to back up yet. */
     ExportNoData,
     ExportFailed,
-
-    /** The picked file could not be read or parsed as a backup. */
     ImportReadFailed,
-
-    /** The picked file is a backup, but its format version is not supported by this build. */
     ImportVersionUnsupported,
-
-    /** The picked file parsed but holds no rooms, so restoring would only wipe existing data. */
     ImportEmpty,
     RestoreFailed,
 }

--- a/shared/feature-rooms/api/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/api/store/BackupErrorKind.kt
+++ b/shared/feature-rooms/api/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/api/store/BackupErrorKind.kt
@@ -1,0 +1,15 @@
+package dev.nonoxy.residetrack.feature.rooms.api.store
+
+/** Why a backup operation failed (or was refused) — the UI resolves each to its own message. */
+enum class BackupErrorKind {
+    /** Export was refused because there is nothing to back up yet. */
+    ExportNoData,
+    ExportFailed,
+
+    /** The picked file could not be read or parsed as a backup. */
+    ImportReadFailed,
+
+    /** The picked file parsed but holds no rooms, so restoring would only wipe existing data. */
+    ImportEmpty,
+    RestoreFailed,
+}

--- a/shared/feature-rooms/api/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/api/store/BackupSuccessKind.kt
+++ b/shared/feature-rooms/api/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/api/store/BackupSuccessKind.kt
@@ -1,4 +1,3 @@
 package dev.nonoxy.residetrack.feature.rooms.api.store
 
-/** Which backup operation succeeded — the UI resolves each to its own message. */
 enum class BackupSuccessKind { Exported, Restored }

--- a/shared/feature-rooms/api/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/api/store/BackupSuccessKind.kt
+++ b/shared/feature-rooms/api/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/api/store/BackupSuccessKind.kt
@@ -1,0 +1,4 @@
+package dev.nonoxy.residetrack.feature.rooms.api.store
+
+/** Which backup operation succeeded — the UI resolves each to its own message. */
+enum class BackupSuccessKind { Exported, Restored }

--- a/shared/feature-rooms/api/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/api/store/RoomsStore.kt
+++ b/shared/feature-rooms/api/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/api/store/RoomsStore.kt
@@ -47,7 +47,3 @@ interface RoomsStore : Store<Intent, State, Label> {
         data class ShowBackupError(val kind: BackupErrorKind) : Label
     }
 }
-
-enum class BackupSuccessKind { Exported, Restored }
-
-enum class BackupErrorKind { ExportFailed, ImportReadFailed, RestoreFailed }

--- a/shared/feature-rooms/api/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/api/store/RoomsStore.kt
+++ b/shared/feature-rooms/api/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/api/store/RoomsStore.kt
@@ -1,6 +1,7 @@
 package dev.nonoxy.residetrack.feature.rooms.api.store
 
 import com.arkivanov.mvikotlin.core.store.Store
+import dev.nonoxy.residetrack.core.backup.domain.model.Backup
 import dev.nonoxy.residetrack.core.rooms.domain.model.Room
 import dev.nonoxy.residetrack.feature.rooms.api.store.RoomsStore.Intent
 import dev.nonoxy.residetrack.feature.rooms.api.store.RoomsStore.Label
@@ -12,16 +13,41 @@ interface RoomsStore : Store<Intent, State, Label> {
         val isLoading: Boolean = false,
         val isError: Boolean = false,
         val roomsOnFloor: Map<Int, List<Room>> = emptyMap(),
+        /** Non-null while the import confirmation dialog is shown — the parsed, not-yet-applied backup. */
+        val importConfirmation: Backup? = null,
     )
 
     sealed interface Intent {
         data class OnRoomClick(val roomId: Long) : Intent
         data object OnAddRoomClick : Intent
         data object OnRetry : Intent
+
+        data object OnExportClick : Intent
+
+        /** Reported by the UI after writing (or failing to write) the exported file to a picked location. */
+        data class OnExportCompleted(val success: Boolean) : Intent
+        data object OnImportClick : Intent
+
+        /** Reported by the UI with the contents of a picked backup file. */
+        data class OnBackupFileLoaded(val json: String) : Intent
+        data object OnRestoreConfirm : Intent
+        data object OnRestoreCancel : Intent
     }
 
     sealed interface Label {
         data object NavigateToAddRoomScreen : Label
         data class NavigateToRoomEditorExistingRoom(val roomId: String) : Label
+
+        /** Asks the UI to write [json] to a user-picked file, defaulting its name to [suggestedName]. */
+        data class SaveBackupFile(val json: String, val suggestedName: String) : Label
+
+        /** Asks the UI to let the user pick a backup file to import. */
+        data object OpenBackupFile : Label
+        data class ShowBackupSuccess(val kind: BackupSuccessKind) : Label
+        data class ShowBackupError(val kind: BackupErrorKind) : Label
     }
 }
+
+enum class BackupSuccessKind { Exported, Restored }
+
+enum class BackupErrorKind { ExportFailed, ImportReadFailed, RestoreFailed }

--- a/shared/feature-rooms/api/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/api/store/RoomsStore.kt
+++ b/shared/feature-rooms/api/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/api/store/RoomsStore.kt
@@ -1,7 +1,7 @@
 package dev.nonoxy.residetrack.feature.rooms.api.store
 
 import com.arkivanov.mvikotlin.core.store.Store
-import dev.nonoxy.residetrack.core.rooms.models.Room
+import dev.nonoxy.residetrack.core.rooms.domain.model.Room
 import dev.nonoxy.residetrack.feature.rooms.api.store.RoomsStore.Intent
 import dev.nonoxy.residetrack.feature.rooms.api.store.RoomsStore.Label
 import dev.nonoxy.residetrack.feature.rooms.api.store.RoomsStore.State

--- a/shared/feature-rooms/impl/build.gradle.kts
+++ b/shared/feature-rooms/impl/build.gradle.kts
@@ -14,9 +14,11 @@ androidLibraryConfig {
 
 commonMainDependencies {
     implementations(
+        projects.shared.common,
         projects.shared.coreDatabase,
         projects.shared.coreInitializer,
         projects.shared.coreRooms,
+        projects.shared.coreBackup,
         projects.shared.commonResources,
     )
 }

--- a/shared/feature-rooms/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/di/FeatureRoomsImplModule.kt
+++ b/shared/feature-rooms/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/di/FeatureRoomsImplModule.kt
@@ -18,6 +18,7 @@ val featureRoomsImplModule = module {
             storeFactory = get(),
             mainDispatcher = get<CoroutineDispatchers>().main,
             roomsRepository = get(),
+            backupRepository = get(),
         ).create()
     }
 }

--- a/shared/feature-rooms/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/domain/RoomsExecutor.kt
+++ b/shared/feature-rooms/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/domain/RoomsExecutor.kt
@@ -54,8 +54,7 @@ internal class RoomsExecutor(
     }
 
     private suspend fun exportBackup() {
-        // Nothing to back up yet — refuse instead of writing a misleading "empty backup" file
-        // and reporting success. roomsOnFloor mirrors the DB contents already loaded into state.
+        // roomsOnFloor mirrors the DB already in state, so emptiness is checkable without a repo call.
         if (state().roomsOnFloor.isEmpty()) {
             publish(Label.ShowBackupError(BackupErrorKind.ExportNoData))
             return
@@ -75,8 +74,7 @@ internal class RoomsExecutor(
     private suspend fun parseBackup(json: String) {
         backupRepository.parse(json)
             .onSuccess { backup ->
-                // A backup with no rooms would only wipe existing data on restore — block it
-                // rather than letting the user confirm a destructive no-op.
+                // Empty backup would only wipe data on restore — block rather than confirm a no-op.
                 if (backup.isEmpty) {
                     publish(Label.ShowBackupError(BackupErrorKind.ImportEmpty))
                 } else {
@@ -96,8 +94,7 @@ internal class RoomsExecutor(
     private suspend fun restoreBackup() {
         val backup = state().importConfirmation ?: return
         dispatch(Message.SetImportConfirmation(backup = null))
-        // Show loading during the replace-all write. On success the observeRooms stream re-emits the
-        // restored data and clears loading; on failure we clear it here since nothing re-emits.
+        // observeRooms re-emits on success and clears loading; on failure nothing re-emits so we clear it.
         dispatch(Message.SetIsLoading(isLoading = true))
         backupRepository.restore(backup)
             .onSuccess { publish(Label.ShowBackupSuccess(BackupSuccessKind.Restored)) }

--- a/shared/feature-rooms/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/domain/RoomsExecutor.kt
+++ b/shared/feature-rooms/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/domain/RoomsExecutor.kt
@@ -1,6 +1,7 @@
 package dev.nonoxy.residetrack.feature.rooms.impl.domain
 
 import dev.nonoxy.residetrack.common.utils.currentLocalDate
+import dev.nonoxy.residetrack.core.backup.domain.model.UnsupportedBackupVersionException
 import dev.nonoxy.residetrack.core.backup.domain.repository.BackupRepository
 import dev.nonoxy.residetrack.core.mvikotlin.BaseExecutor
 import dev.nonoxy.residetrack.core.rooms.domain.model.Room
@@ -82,7 +83,14 @@ internal class RoomsExecutor(
                     dispatch(Message.SetImportConfirmation(backup = backup))
                 }
             }
-            .onFailure { publish(Label.ShowBackupError(BackupErrorKind.ImportReadFailed)) }
+            .onFailure { error ->
+                val kind = if (error is UnsupportedBackupVersionException) {
+                    BackupErrorKind.ImportVersionUnsupported
+                } else {
+                    BackupErrorKind.ImportReadFailed
+                }
+                publish(Label.ShowBackupError(kind))
+            }
     }
 
     private suspend fun restoreBackup() {

--- a/shared/feature-rooms/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/domain/RoomsExecutor.kt
+++ b/shared/feature-rooms/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/domain/RoomsExecutor.kt
@@ -1,9 +1,10 @@
 package dev.nonoxy.residetrack.feature.rooms.impl.domain
 
+import dev.nonoxy.residetrack.common.utils.currentLocalDate
 import dev.nonoxy.residetrack.core.backup.domain.repository.BackupRepository
+import dev.nonoxy.residetrack.core.mvikotlin.BaseExecutor
 import dev.nonoxy.residetrack.core.rooms.domain.model.Room
 import dev.nonoxy.residetrack.core.rooms.domain.repository.RoomsRepository
-import dev.nonoxy.residetrack.common.utils.currentLocalDate
 import dev.nonoxy.residetrack.feature.rooms.api.store.BackupErrorKind
 import dev.nonoxy.residetrack.feature.rooms.api.store.BackupSuccessKind
 import dev.nonoxy.residetrack.feature.rooms.api.store.RoomsStore.Intent
@@ -11,7 +12,6 @@ import dev.nonoxy.residetrack.feature.rooms.api.store.RoomsStore.Label
 import dev.nonoxy.residetrack.feature.rooms.api.store.RoomsStore.State
 import dev.nonoxy.residetrack.feature.rooms.impl.domain.RoomsStoreFactory.Action
 import dev.nonoxy.residetrack.feature.rooms.impl.domain.RoomsStoreFactory.Message
-import dev.nonoxy.residetrack.core.mvikotlin.BaseExecutor
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.catch
 
@@ -32,6 +32,7 @@ internal class RoomsExecutor(
             is Intent.OnRoomClick -> publish(
                 Label.NavigateToRoomEditorExistingRoom(roomId = intent.roomId.toString())
             )
+
             Intent.OnAddRoomClick -> publish(Label.NavigateToAddRoomScreen)
             Intent.OnRetry -> loadRoomsData()
 
@@ -43,6 +44,7 @@ internal class RoomsExecutor(
                     Label.ShowBackupError(BackupErrorKind.ExportFailed)
                 }
             )
+
             Intent.OnImportClick -> publish(Label.OpenBackupFile)
             is Intent.OnBackupFileLoaded -> parseBackup(intent.json)
             Intent.OnRestoreConfirm -> restoreBackup()
@@ -51,6 +53,12 @@ internal class RoomsExecutor(
     }
 
     private suspend fun exportBackup() {
+        // Nothing to back up yet — refuse instead of writing a misleading "empty backup" file
+        // and reporting success. roomsOnFloor mirrors the DB contents already loaded into state.
+        if (state().roomsOnFloor.isEmpty()) {
+            publish(Label.ShowBackupError(BackupErrorKind.ExportNoData))
+            return
+        }
         backupRepository.export()
             .onSuccess { json ->
                 publish(
@@ -65,7 +73,15 @@ internal class RoomsExecutor(
 
     private suspend fun parseBackup(json: String) {
         backupRepository.parse(json)
-            .onSuccess { backup -> dispatch(Message.SetImportConfirmation(backup = backup)) }
+            .onSuccess { backup ->
+                // A backup with no rooms would only wipe existing data on restore — block it
+                // rather than letting the user confirm a destructive no-op.
+                if (backup.isEmpty) {
+                    publish(Label.ShowBackupError(BackupErrorKind.ImportEmpty))
+                } else {
+                    dispatch(Message.SetImportConfirmation(backup = backup))
+                }
+            }
             .onFailure { publish(Label.ShowBackupError(BackupErrorKind.ImportReadFailed)) }
     }
 

--- a/shared/feature-rooms/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/domain/RoomsExecutor.kt
+++ b/shared/feature-rooms/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/domain/RoomsExecutor.kt
@@ -1,7 +1,11 @@
 package dev.nonoxy.residetrack.feature.rooms.impl.domain
 
+import dev.nonoxy.residetrack.core.backup.domain.repository.BackupRepository
 import dev.nonoxy.residetrack.core.rooms.domain.model.Room
 import dev.nonoxy.residetrack.core.rooms.domain.repository.RoomsRepository
+import dev.nonoxy.residetrack.common.utils.currentLocalDate
+import dev.nonoxy.residetrack.feature.rooms.api.store.BackupErrorKind
+import dev.nonoxy.residetrack.feature.rooms.api.store.BackupSuccessKind
 import dev.nonoxy.residetrack.feature.rooms.api.store.RoomsStore.Intent
 import dev.nonoxy.residetrack.feature.rooms.api.store.RoomsStore.Label
 import dev.nonoxy.residetrack.feature.rooms.api.store.RoomsStore.State
@@ -14,6 +18,7 @@ import kotlinx.coroutines.flow.catch
 internal class RoomsExecutor(
     mainDispatcher: CoroutineDispatcher,
     private val roomsRepository: RoomsRepository,
+    private val backupRepository: BackupRepository,
 ) : BaseExecutor<Intent, Action, State, Message, Label>(mainContext = mainDispatcher) {
 
     override suspend fun suspendExecuteAction(action: Action) {
@@ -29,7 +34,47 @@ internal class RoomsExecutor(
             )
             Intent.OnAddRoomClick -> publish(Label.NavigateToAddRoomScreen)
             Intent.OnRetry -> loadRoomsData()
+
+            Intent.OnExportClick -> exportBackup()
+            is Intent.OnExportCompleted -> publish(
+                if (intent.success) {
+                    Label.ShowBackupSuccess(BackupSuccessKind.Exported)
+                } else {
+                    Label.ShowBackupError(BackupErrorKind.ExportFailed)
+                }
+            )
+            Intent.OnImportClick -> publish(Label.OpenBackupFile)
+            is Intent.OnBackupFileLoaded -> parseBackup(intent.json)
+            Intent.OnRestoreConfirm -> restoreBackup()
+            Intent.OnRestoreCancel -> dispatch(Message.SetImportConfirmation(backup = null))
         }
+    }
+
+    private suspend fun exportBackup() {
+        backupRepository.export()
+            .onSuccess { json ->
+                publish(
+                    Label.SaveBackupFile(
+                        json = json,
+                        suggestedName = "reside-track-backup-$currentLocalDate.json",
+                    )
+                )
+            }
+            .onFailure { publish(Label.ShowBackupError(BackupErrorKind.ExportFailed)) }
+    }
+
+    private suspend fun parseBackup(json: String) {
+        backupRepository.parse(json)
+            .onSuccess { backup -> dispatch(Message.SetImportConfirmation(backup = backup)) }
+            .onFailure { publish(Label.ShowBackupError(BackupErrorKind.ImportReadFailed)) }
+    }
+
+    private suspend fun restoreBackup() {
+        val backup = state().importConfirmation ?: return
+        dispatch(Message.SetImportConfirmation(backup = null))
+        backupRepository.restore(backup)
+            .onSuccess { publish(Label.ShowBackupSuccess(BackupSuccessKind.Restored)) }
+            .onFailure { publish(Label.ShowBackupError(BackupErrorKind.RestoreFailed)) }
     }
 
     private suspend fun loadRoomsData() {

--- a/shared/feature-rooms/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/domain/RoomsExecutor.kt
+++ b/shared/feature-rooms/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/domain/RoomsExecutor.kt
@@ -96,9 +96,15 @@ internal class RoomsExecutor(
     private suspend fun restoreBackup() {
         val backup = state().importConfirmation ?: return
         dispatch(Message.SetImportConfirmation(backup = null))
+        // Show loading during the replace-all write. On success the observeRooms stream re-emits the
+        // restored data and clears loading; on failure we clear it here since nothing re-emits.
+        dispatch(Message.SetIsLoading(isLoading = true))
         backupRepository.restore(backup)
             .onSuccess { publish(Label.ShowBackupSuccess(BackupSuccessKind.Restored)) }
-            .onFailure { publish(Label.ShowBackupError(BackupErrorKind.RestoreFailed)) }
+            .onFailure {
+                dispatch(Message.SetIsLoading(isLoading = false))
+                publish(Label.ShowBackupError(BackupErrorKind.RestoreFailed))
+            }
     }
 
     private suspend fun loadRoomsData() {

--- a/shared/feature-rooms/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/domain/RoomsExecutor.kt
+++ b/shared/feature-rooms/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/domain/RoomsExecutor.kt
@@ -1,7 +1,7 @@
 package dev.nonoxy.residetrack.feature.rooms.impl.domain
 
-import dev.nonoxy.residetrack.core.rooms.models.Room
-import dev.nonoxy.residetrack.core.rooms.repository.RoomsRepository
+import dev.nonoxy.residetrack.core.rooms.domain.model.Room
+import dev.nonoxy.residetrack.core.rooms.domain.repository.RoomsRepository
 import dev.nonoxy.residetrack.feature.rooms.api.store.RoomsStore.Intent
 import dev.nonoxy.residetrack.feature.rooms.api.store.RoomsStore.Label
 import dev.nonoxy.residetrack.feature.rooms.api.store.RoomsStore.State

--- a/shared/feature-rooms/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/domain/RoomsReducer.kt
+++ b/shared/feature-rooms/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/domain/RoomsReducer.kt
@@ -22,5 +22,9 @@ internal class RoomsReducer : Reducer<State, Message> {
             isError = false,
             roomsOnFloor = msg.roomsOnFloor,
         )
+
+        is Message.SetImportConfirmation -> copy(
+            importConfirmation = msg.backup,
+        )
     }
 }

--- a/shared/feature-rooms/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/domain/RoomsStoreFactory.kt
+++ b/shared/feature-rooms/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/domain/RoomsStoreFactory.kt
@@ -3,6 +3,8 @@ package dev.nonoxy.residetrack.feature.rooms.impl.domain
 import com.arkivanov.mvikotlin.core.store.SimpleBootstrapper
 import com.arkivanov.mvikotlin.core.store.Store
 import com.arkivanov.mvikotlin.core.store.StoreFactory
+import dev.nonoxy.residetrack.core.backup.domain.model.Backup
+import dev.nonoxy.residetrack.core.backup.domain.repository.BackupRepository
 import dev.nonoxy.residetrack.core.rooms.domain.model.Room
 import dev.nonoxy.residetrack.core.rooms.domain.repository.RoomsRepository
 import dev.nonoxy.residetrack.feature.rooms.api.store.RoomsStore
@@ -15,6 +17,7 @@ internal class RoomsStoreFactory(
     private val storeFactory: StoreFactory,
     private val mainDispatcher: CoroutineDispatcher,
     private val roomsRepository: RoomsRepository,
+    private val backupRepository: BackupRepository,
 ) {
 
     fun create(): RoomsStore =
@@ -28,6 +31,7 @@ internal class RoomsStoreFactory(
                     RoomsExecutor(
                         mainDispatcher = mainDispatcher,
                         roomsRepository = roomsRepository,
+                        backupRepository = backupRepository,
                     )
                 },
                 reducer = RoomsReducer()
@@ -41,5 +45,6 @@ internal class RoomsStoreFactory(
         data class SetIsLoading(val isLoading: Boolean) : Message
         data object SetError : Message
         data class SetRoomsOnFloor(val roomsOnFloor: Map<Int, List<Room>>) : Message
+        data class SetImportConfirmation(val backup: Backup?) : Message
     }
 }

--- a/shared/feature-rooms/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/domain/RoomsStoreFactory.kt
+++ b/shared/feature-rooms/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/domain/RoomsStoreFactory.kt
@@ -3,8 +3,8 @@ package dev.nonoxy.residetrack.feature.rooms.impl.domain
 import com.arkivanov.mvikotlin.core.store.SimpleBootstrapper
 import com.arkivanov.mvikotlin.core.store.Store
 import com.arkivanov.mvikotlin.core.store.StoreFactory
-import dev.nonoxy.residetrack.core.rooms.models.Room
-import dev.nonoxy.residetrack.core.rooms.repository.RoomsRepository
+import dev.nonoxy.residetrack.core.rooms.domain.model.Room
+import dev.nonoxy.residetrack.core.rooms.domain.repository.RoomsRepository
 import dev.nonoxy.residetrack.feature.rooms.api.store.RoomsStore
 import dev.nonoxy.residetrack.feature.rooms.api.store.RoomsStore.Intent
 import dev.nonoxy.residetrack.feature.rooms.api.store.RoomsStore.Label

--- a/shared/feature-rooms/impl/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/data/FakeBackupRepository.kt
+++ b/shared/feature-rooms/impl/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/data/FakeBackupRepository.kt
@@ -1,0 +1,23 @@
+package dev.nonoxy.residetrack.feature.rooms.impl.data
+
+import dev.nonoxy.residetrack.core.backup.domain.model.Backup
+import dev.nonoxy.residetrack.core.backup.domain.repository.BackupRepository
+
+internal class FakeBackupRepository(
+    private val exportResult: Result<String> = Result.success("{}"),
+    private val parseResult: Result<Backup> = Result.success(Backup(rooms = emptyList())),
+    private val restoreResult: Result<Unit> = Result.success(Unit),
+) : BackupRepository {
+
+    var restoreCalledWith: Backup? = null
+        private set
+
+    override suspend fun export(): Result<String> = exportResult
+
+    override suspend fun parse(rawJson: String): Result<Backup> = parseResult
+
+    override suspend fun restore(backup: Backup): Result<Unit> {
+        restoreCalledWith = backup
+        return restoreResult
+    }
+}

--- a/shared/feature-rooms/impl/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/data/FakeRoomsRepository.kt
+++ b/shared/feature-rooms/impl/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/data/FakeRoomsRepository.kt
@@ -1,7 +1,7 @@
 package dev.nonoxy.residetrack.feature.rooms.impl.data
 
-import dev.nonoxy.residetrack.core.rooms.models.Room
-import dev.nonoxy.residetrack.core.rooms.repository.RoomsRepository
+import dev.nonoxy.residetrack.core.rooms.domain.model.Room
+import dev.nonoxy.residetrack.core.rooms.domain.repository.RoomsRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flow

--- a/shared/feature-rooms/impl/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/domain/RoomsExecutorTest.kt
+++ b/shared/feature-rooms/impl/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/domain/RoomsExecutorTest.kt
@@ -2,7 +2,7 @@ package dev.nonoxy.residetrack.feature.rooms.impl.domain
 
 import com.arkivanov.mvikotlin.extensions.coroutines.labels
 import com.arkivanov.mvikotlin.main.store.DefaultStoreFactory
-import dev.nonoxy.residetrack.core.rooms.models.Room
+import dev.nonoxy.residetrack.core.rooms.domain.model.Room
 import dev.nonoxy.residetrack.feature.rooms.api.store.RoomsStore
 import dev.nonoxy.residetrack.feature.rooms.api.store.RoomsStore.Intent
 import dev.nonoxy.residetrack.feature.rooms.api.store.RoomsStore.Label

--- a/shared/feature-rooms/impl/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/domain/RoomsExecutorTest.kt
+++ b/shared/feature-rooms/impl/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/domain/RoomsExecutorTest.kt
@@ -156,7 +156,7 @@ class RoomsExecutorTest {
     @Test
     fun `OnExportClick on success asks UI to save the exported file`() = runTest {
         val backup = FakeBackupRepository(exportResult = Result.success("{\"version\":1}"))
-        val store = createStore(FakeRoomsRepository(), backup)
+        val store = createStore(FakeRoomsRepository(rooms = listOf(room(id = 1, floor = 3, number = 329))), backup)
         val labels = collectLabels(store)
 
         store.accept(Intent.OnExportClick)
@@ -174,7 +174,7 @@ class RoomsExecutorTest {
     @Test
     fun `OnExportClick on failure shows an export error`() = runTest {
         val backup = FakeBackupRepository(exportResult = Result.failure(RuntimeException("boom")))
-        val store = createStore(FakeRoomsRepository(), backup)
+        val store = createStore(FakeRoomsRepository(rooms = listOf(room(id = 1, floor = 3, number = 329))), backup)
         val labels = collectLabels(store)
 
         store.accept(Intent.OnExportClick)
@@ -276,6 +276,35 @@ class RoomsExecutorTest {
 
         assertNull(store.state.importConfirmation)
         assertNull(backup.restoreCalledWith)
+
+        store.dispose()
+    }
+
+    @Test
+    fun `OnExportClick with an empty database refuses without exporting`() = runTest {
+        val backup = FakeBackupRepository(exportResult = Result.success("{\"version\":1}"))
+        val store = createStore(FakeRoomsRepository(rooms = emptyList()), backup)
+        val labels = collectLabels(store)
+
+        store.accept(Intent.OnExportClick)
+        advanceUntilIdle()
+
+        assertEquals(listOf<Label>(Label.ShowBackupError(BackupErrorKind.ExportNoData)), labels)
+
+        store.dispose()
+    }
+
+    @Test
+    fun `OnBackupFileLoaded with an empty backup is refused and shows no confirmation`() = runTest {
+        val backup = FakeBackupRepository(parseResult = Result.success(Backup(rooms = emptyList())))
+        val store = createStore(FakeRoomsRepository(), backup)
+        val labels = collectLabels(store)
+
+        store.accept(Intent.OnBackupFileLoaded(json = "{}"))
+        advanceUntilIdle()
+
+        assertEquals(listOf<Label>(Label.ShowBackupError(BackupErrorKind.ImportEmpty)), labels)
+        assertNull(store.state.importConfirmation)
 
         store.dispose()
     }

--- a/shared/feature-rooms/impl/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/domain/RoomsExecutorTest.kt
+++ b/shared/feature-rooms/impl/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/domain/RoomsExecutorTest.kt
@@ -281,6 +281,27 @@ class RoomsExecutorTest {
     }
 
     @Test
+    fun `OnRestoreConfirm failure clears loading and shows a restore error`() = runTest {
+        val backup = FakeBackupRepository(
+            parseResult = Result.success(sampleBackup),
+            restoreResult = Result.failure(RuntimeException("disk full")),
+        )
+        val store = createStore(FakeRoomsRepository(), backup)
+        val labels = collectLabels(store)
+        store.accept(Intent.OnBackupFileLoaded(json = "{}"))
+        advanceUntilIdle()
+
+        store.accept(Intent.OnRestoreConfirm)
+        advanceUntilIdle()
+
+        assertEquals(listOf<Label>(Label.ShowBackupError(BackupErrorKind.RestoreFailed)), labels)
+        assertFalse(store.state.isLoading)
+        assertNull(store.state.importConfirmation)
+
+        store.dispose()
+    }
+
+    @Test
     fun `OnRestoreCancel clears the confirmation without restoring`() = runTest {
         val backup = FakeBackupRepository(parseResult = Result.success(sampleBackup))
         val store = createStore(FakeRoomsRepository(), backup)

--- a/shared/feature-rooms/impl/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/domain/RoomsExecutorTest.kt
+++ b/shared/feature-rooms/impl/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/domain/RoomsExecutorTest.kt
@@ -4,6 +4,7 @@ import com.arkivanov.mvikotlin.extensions.coroutines.labels
 import com.arkivanov.mvikotlin.main.store.DefaultStoreFactory
 import dev.nonoxy.residetrack.core.backup.domain.model.Backup
 import dev.nonoxy.residetrack.core.backup.domain.model.BackupRoom
+import dev.nonoxy.residetrack.core.backup.domain.model.UnsupportedBackupVersionException
 import dev.nonoxy.residetrack.core.rooms.domain.model.Room
 import dev.nonoxy.residetrack.feature.rooms.api.store.BackupErrorKind
 import dev.nonoxy.residetrack.feature.rooms.api.store.BackupSuccessKind
@@ -241,6 +242,21 @@ class RoomsExecutorTest {
         advanceUntilIdle()
 
         assertEquals(listOf<Label>(Label.ShowBackupError(BackupErrorKind.ImportReadFailed)), labels)
+        assertNull(store.state.importConfirmation)
+
+        store.dispose()
+    }
+
+    @Test
+    fun `OnBackupFileLoaded with an unsupported version shows a version error`() = runTest {
+        val backup = FakeBackupRepository(parseResult = Result.failure(UnsupportedBackupVersionException(999)))
+        val store = createStore(FakeRoomsRepository(), backup)
+        val labels = collectLabels(store)
+
+        store.accept(Intent.OnBackupFileLoaded(json = "{\"version\":999}"))
+        advanceUntilIdle()
+
+        assertEquals(listOf<Label>(Label.ShowBackupError(BackupErrorKind.ImportVersionUnsupported)), labels)
         assertNull(store.state.importConfirmation)
 
         store.dispose()

--- a/shared/feature-rooms/impl/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/domain/RoomsExecutorTest.kt
+++ b/shared/feature-rooms/impl/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/domain/RoomsExecutorTest.kt
@@ -2,10 +2,15 @@ package dev.nonoxy.residetrack.feature.rooms.impl.domain
 
 import com.arkivanov.mvikotlin.extensions.coroutines.labels
 import com.arkivanov.mvikotlin.main.store.DefaultStoreFactory
+import dev.nonoxy.residetrack.core.backup.domain.model.Backup
+import dev.nonoxy.residetrack.core.backup.domain.model.BackupRoom
 import dev.nonoxy.residetrack.core.rooms.domain.model.Room
+import dev.nonoxy.residetrack.feature.rooms.api.store.BackupErrorKind
+import dev.nonoxy.residetrack.feature.rooms.api.store.BackupSuccessKind
 import dev.nonoxy.residetrack.feature.rooms.api.store.RoomsStore
 import dev.nonoxy.residetrack.feature.rooms.api.store.RoomsStore.Intent
 import dev.nonoxy.residetrack.feature.rooms.api.store.RoomsStore.Label
+import dev.nonoxy.residetrack.feature.rooms.impl.data.FakeBackupRepository
 import dev.nonoxy.residetrack.feature.rooms.impl.data.FakeRoomsRepository
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
@@ -17,6 +22,7 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -25,11 +31,15 @@ class RoomsExecutorTest {
     private fun room(id: Long, floor: Int, number: Int, beds: Int = 4) =
         Room(id = id, floorNumber = floor, roomNumber = number, bedsCount = beds, students = emptyList())
 
-    private fun TestScope.createStore(repository: FakeRoomsRepository): RoomsStore =
+    private fun TestScope.createStore(
+        repository: FakeRoomsRepository,
+        backupRepository: FakeBackupRepository = FakeBackupRepository(),
+    ): RoomsStore =
         RoomsStoreFactory(
             storeFactory = DefaultStoreFactory(),
             mainDispatcher = UnconfinedTestDispatcher(testScheduler),
             roomsRepository = repository,
+            backupRepository = backupRepository,
         ).create()
 
     @Test
@@ -128,6 +138,144 @@ class RoomsExecutorTest {
         advanceUntilIdle()
 
         assertEquals(listOf<Label>(Label.NavigateToAddRoomScreen), labels)
+
+        store.dispose()
+    }
+
+    private val sampleBackup = Backup(
+        rooms = listOf(BackupRoom(floorNumber = 3, roomNumber = 329, bedsCount = 5, students = emptyList())),
+    )
+
+    private fun TestScope.collectLabels(store: RoomsStore): MutableList<Label> {
+        val labels = mutableListOf<Label>()
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) { store.labels.collect { labels.add(it) } }
+        runCurrent()
+        return labels
+    }
+
+    @Test
+    fun `OnExportClick on success asks UI to save the exported file`() = runTest {
+        val backup = FakeBackupRepository(exportResult = Result.success("{\"version\":1}"))
+        val store = createStore(FakeRoomsRepository(), backup)
+        val labels = collectLabels(store)
+
+        store.accept(Intent.OnExportClick)
+        advanceUntilIdle()
+
+        val label = labels.single()
+        assertTrue(label is Label.SaveBackupFile)
+        assertEquals("{\"version\":1}", label.json)
+        assertTrue(label.suggestedName.startsWith("reside-track-backup-"))
+        assertTrue(label.suggestedName.endsWith(".json"))
+
+        store.dispose()
+    }
+
+    @Test
+    fun `OnExportClick on failure shows an export error`() = runTest {
+        val backup = FakeBackupRepository(exportResult = Result.failure(RuntimeException("boom")))
+        val store = createStore(FakeRoomsRepository(), backup)
+        val labels = collectLabels(store)
+
+        store.accept(Intent.OnExportClick)
+        advanceUntilIdle()
+
+        assertEquals(listOf<Label>(Label.ShowBackupError(BackupErrorKind.ExportFailed)), labels)
+
+        store.dispose()
+    }
+
+    @Test
+    fun `OnExportCompleted maps success and failure to the right labels`() = runTest {
+        val store = createStore(FakeRoomsRepository())
+        val labels = collectLabels(store)
+
+        store.accept(Intent.OnExportCompleted(success = true))
+        store.accept(Intent.OnExportCompleted(success = false))
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf<Label>(
+                Label.ShowBackupSuccess(BackupSuccessKind.Exported),
+                Label.ShowBackupError(BackupErrorKind.ExportFailed),
+            ),
+            labels,
+        )
+
+        store.dispose()
+    }
+
+    @Test
+    fun `OnImportClick asks UI to pick a backup file`() = runTest {
+        val store = createStore(FakeRoomsRepository())
+        val labels = collectLabels(store)
+
+        store.accept(Intent.OnImportClick)
+        advanceUntilIdle()
+
+        assertEquals(listOf<Label>(Label.OpenBackupFile), labels)
+
+        store.dispose()
+    }
+
+    @Test
+    fun `OnBackupFileLoaded with a valid file opens the confirmation`() = runTest {
+        val backup = FakeBackupRepository(parseResult = Result.success(sampleBackup))
+        val store = createStore(FakeRoomsRepository(), backup)
+
+        store.accept(Intent.OnBackupFileLoaded(json = "{}"))
+        advanceUntilIdle()
+
+        assertEquals(sampleBackup, store.state.importConfirmation)
+
+        store.dispose()
+    }
+
+    @Test
+    fun `OnBackupFileLoaded with an unreadable file shows an error and no confirmation`() = runTest {
+        val backup = FakeBackupRepository(parseResult = Result.failure(RuntimeException("bad")))
+        val store = createStore(FakeRoomsRepository(), backup)
+        val labels = collectLabels(store)
+
+        store.accept(Intent.OnBackupFileLoaded(json = "garbage"))
+        advanceUntilIdle()
+
+        assertEquals(listOf<Label>(Label.ShowBackupError(BackupErrorKind.ImportReadFailed)), labels)
+        assertNull(store.state.importConfirmation)
+
+        store.dispose()
+    }
+
+    @Test
+    fun `OnRestoreConfirm restores and clears the confirmation`() = runTest {
+        val backup = FakeBackupRepository(parseResult = Result.success(sampleBackup))
+        val store = createStore(FakeRoomsRepository(), backup)
+        val labels = collectLabels(store)
+        store.accept(Intent.OnBackupFileLoaded(json = "{}"))
+        advanceUntilIdle()
+
+        store.accept(Intent.OnRestoreConfirm)
+        advanceUntilIdle()
+
+        assertEquals(sampleBackup, backup.restoreCalledWith)
+        assertEquals(listOf<Label>(Label.ShowBackupSuccess(BackupSuccessKind.Restored)), labels)
+        assertNull(store.state.importConfirmation)
+
+        store.dispose()
+    }
+
+    @Test
+    fun `OnRestoreCancel clears the confirmation without restoring`() = runTest {
+        val backup = FakeBackupRepository(parseResult = Result.success(sampleBackup))
+        val store = createStore(FakeRoomsRepository(), backup)
+        store.accept(Intent.OnBackupFileLoaded(json = "{}"))
+        advanceUntilIdle()
+
+        store.accept(Intent.OnRestoreCancel)
+        advanceUntilIdle()
+
+        assertNull(store.state.importConfirmation)
+        assertNull(backup.restoreCalledWith)
 
         store.dispose()
     }

--- a/shared/feature-rooms/presentation/build.gradle.kts
+++ b/shared/feature-rooms/presentation/build.gradle.kts
@@ -13,6 +13,7 @@ androidLibraryConfig {
 
 commonMainDependencies {
     implementations(
+        projects.shared.commonResources,
         libs.kotlin.immutableCollections,
     )
 }

--- a/shared/feature-rooms/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/presentation/RoomsViewModel.kt
+++ b/shared/feature-rooms/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/presentation/RoomsViewModel.kt
@@ -30,6 +30,18 @@ class RoomsViewModel internal constructor(
 
     fun onRetryClick() = store.accept(Intent.OnRetry)
 
+    fun onExportClick() = store.accept(Intent.OnExportClick)
+
+    fun onExportCompleted(success: Boolean) = store.accept(Intent.OnExportCompleted(success = success))
+
+    fun onImportClick() = store.accept(Intent.OnImportClick)
+
+    fun onBackupFileLoaded(json: String) = store.accept(Intent.OnBackupFileLoaded(json = json))
+
+    fun onRestoreConfirm() = store.accept(Intent.OnRestoreConfirm)
+
+    fun onRestoreCancel() = store.accept(Intent.OnRestoreCancel)
+
     override fun onCleared() {
         store.dispose()
         super.onCleared()

--- a/shared/feature-rooms/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/presentation/di/FeatureRoomsPresentationModule.kt
+++ b/shared/feature-rooms/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/presentation/di/FeatureRoomsPresentationModule.kt
@@ -22,7 +22,7 @@ val featureRoomsPresentationModule = module {
     factoryOf<UiStudentMapper>(::UiStudentMapperImpl)
     factoryOf(::UiRoomMapperImpl) bind UiRoomMapper::class
     factoryOf(::UiRoomsStateMapperImpl) bind UiRoomsStateMapper::class
-    factoryOf<UiRoomsLabelMapper>(::UiRoomsLabelMapperImpl)
+    factoryOf(::UiRoomsLabelMapperImpl) bind UiRoomsLabelMapper::class
 
     viewModelOf(::RoomsViewModel)
 }

--- a/shared/feature-rooms/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/presentation/mappers/UiRoomMapper.kt
+++ b/shared/feature-rooms/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/presentation/mappers/UiRoomMapper.kt
@@ -1,7 +1,7 @@
 package dev.nonoxy.residetrack.feature.rooms.presentation.mappers
 
 import dev.nonoxy.residetrack.common.utils.mapper.Mapper
-import dev.nonoxy.residetrack.core.rooms.models.Room
+import dev.nonoxy.residetrack.core.rooms.domain.model.Room
 import dev.nonoxy.residetrack.feature.rooms.presentation.models.UiRoom
 import kotlinx.collections.immutable.toImmutableList
 

--- a/shared/feature-rooms/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/presentation/mappers/UiRoomsLabelMapper.kt
+++ b/shared/feature-rooms/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/presentation/mappers/UiRoomsLabelMapper.kt
@@ -1,13 +1,19 @@
 package dev.nonoxy.residetrack.feature.rooms.presentation.mappers
 
+import dev.nonoxy.residetrack.common.resources.StringConverter
+import dev.nonoxy.residetrack.feature.rooms.api.store.BackupErrorKind
+import dev.nonoxy.residetrack.feature.rooms.api.store.BackupSuccessKind
 import dev.nonoxy.residetrack.feature.rooms.api.store.RoomsStore
 import dev.nonoxy.residetrack.feature.rooms.presentation.models.UiRoomsLabel
+import dev.nonoxy.residetrack.res.MR
 
 internal interface UiRoomsLabelMapper {
     fun map(item: RoomsStore.Label): UiRoomsLabel
 }
 
-internal class UiRoomsLabelMapperImpl : UiRoomsLabelMapper {
+internal class UiRoomsLabelMapperImpl(
+    private val stringConverter: StringConverter,
+) : UiRoomsLabelMapper {
 
     override fun map(item: RoomsStore.Label): UiRoomsLabel = when (item) {
         RoomsStore.Label.NavigateToAddRoomScreen ->
@@ -15,5 +21,28 @@ internal class UiRoomsLabelMapperImpl : UiRoomsLabelMapper {
 
         is RoomsStore.Label.NavigateToRoomEditorExistingRoom ->
             UiRoomsLabel.NavigateToRoomEditorExistingRoom(roomId = item.roomId)
+
+        is RoomsStore.Label.SaveBackupFile ->
+            UiRoomsLabel.SaveBackupFile(json = item.json, suggestedName = item.suggestedName)
+
+        RoomsStore.Label.OpenBackupFile ->
+            UiRoomsLabel.OpenBackupFile
+
+        is RoomsStore.Label.ShowBackupSuccess ->
+            UiRoomsLabel.ShowBackupSuccess(message = item.kind.toMessage())
+
+        is RoomsStore.Label.ShowBackupError ->
+            UiRoomsLabel.ShowBackupError(message = item.kind.toMessage())
+    }
+
+    private fun BackupSuccessKind.toMessage(): String = when (this) {
+        BackupSuccessKind.Exported -> stringConverter.convert(MR.strings.backup_export_success)
+        BackupSuccessKind.Restored -> stringConverter.convert(MR.strings.backup_import_success)
+    }
+
+    private fun BackupErrorKind.toMessage(): String = when (this) {
+        BackupErrorKind.ExportFailed -> stringConverter.convert(MR.strings.backup_export_error)
+        BackupErrorKind.ImportReadFailed -> stringConverter.convert(MR.strings.backup_import_error)
+        BackupErrorKind.RestoreFailed -> stringConverter.convert(MR.strings.backup_restore_error)
     }
 }

--- a/shared/feature-rooms/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/presentation/mappers/UiRoomsLabelMapper.kt
+++ b/shared/feature-rooms/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/presentation/mappers/UiRoomsLabelMapper.kt
@@ -41,8 +41,10 @@ internal class UiRoomsLabelMapperImpl(
     }
 
     private fun BackupErrorKind.toMessage(): String = when (this) {
+        BackupErrorKind.ExportNoData -> stringConverter.convert(MR.strings.backup_export_empty)
         BackupErrorKind.ExportFailed -> stringConverter.convert(MR.strings.backup_export_error)
         BackupErrorKind.ImportReadFailed -> stringConverter.convert(MR.strings.backup_import_error)
+        BackupErrorKind.ImportEmpty -> stringConverter.convert(MR.strings.backup_import_empty)
         BackupErrorKind.RestoreFailed -> stringConverter.convert(MR.strings.backup_restore_error)
     }
 }

--- a/shared/feature-rooms/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/presentation/mappers/UiRoomsLabelMapper.kt
+++ b/shared/feature-rooms/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/presentation/mappers/UiRoomsLabelMapper.kt
@@ -44,6 +44,8 @@ internal class UiRoomsLabelMapperImpl(
         BackupErrorKind.ExportNoData -> stringConverter.convert(MR.strings.backup_export_empty)
         BackupErrorKind.ExportFailed -> stringConverter.convert(MR.strings.backup_export_error)
         BackupErrorKind.ImportReadFailed -> stringConverter.convert(MR.strings.backup_import_error)
+        BackupErrorKind.ImportVersionUnsupported ->
+            stringConverter.convert(MR.strings.backup_import_error_version)
         BackupErrorKind.ImportEmpty -> stringConverter.convert(MR.strings.backup_import_empty)
         BackupErrorKind.RestoreFailed -> stringConverter.convert(MR.strings.backup_restore_error)
     }

--- a/shared/feature-rooms/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/presentation/mappers/UiRoomsStateMapper.kt
+++ b/shared/feature-rooms/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/presentation/mappers/UiRoomsStateMapper.kt
@@ -28,7 +28,12 @@ internal class UiRoomsStateMapperImpl(
                 .mapValues { entry -> entry.value.let(roomMapper::map).toPersistentList() }
                 .toPersistentMap(),
             importConfirmation = item.importConfirmation?.let { backup ->
-                UiImportConfirmation(roomCount = backup.roomCount, studentCount = backup.studentCount)
+                UiImportConfirmation(
+                    roomCount = backup.roomCount,
+                    studentCount = backup.studentCount,
+                    currentRoomCount = allRooms.size,
+                    currentStudentCount = occupiedPlaces,
+                )
             },
         )
     }

--- a/shared/feature-rooms/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/presentation/mappers/UiRoomsStateMapper.kt
+++ b/shared/feature-rooms/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/presentation/mappers/UiRoomsStateMapper.kt
@@ -1,6 +1,7 @@
 package dev.nonoxy.residetrack.feature.rooms.presentation.mappers
 
 import dev.nonoxy.residetrack.feature.rooms.api.store.RoomsStore
+import dev.nonoxy.residetrack.feature.rooms.presentation.models.UiImportConfirmation
 import dev.nonoxy.residetrack.feature.rooms.presentation.models.UiRoomsState
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap
@@ -25,7 +26,10 @@ internal class UiRoomsStateMapperImpl(
             availablePlaces = (totalPlaces - occupiedPlaces).coerceAtLeast(0),
             roomsOnFloor = item.roomsOnFloor
                 .mapValues { entry -> entry.value.let(roomMapper::map).toPersistentList() }
-                .toPersistentMap()
+                .toPersistentMap(),
+            importConfirmation = item.importConfirmation?.let { backup ->
+                UiImportConfirmation(roomCount = backup.roomCount, studentCount = backup.studentCount)
+            },
         )
     }
 }

--- a/shared/feature-rooms/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/presentation/mappers/UiStudentMapper.kt
+++ b/shared/feature-rooms/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/presentation/mappers/UiStudentMapper.kt
@@ -1,7 +1,7 @@
 package dev.nonoxy.residetrack.feature.rooms.presentation.mappers
 
 import dev.nonoxy.residetrack.common.utils.mapper.Mapper
-import dev.nonoxy.residetrack.core.rooms.models.Student
+import dev.nonoxy.residetrack.core.rooms.domain.model.Student
 import dev.nonoxy.residetrack.feature.rooms.presentation.models.UiStudent
 
 internal interface UiStudentMapper : Mapper<Student, UiStudent>

--- a/shared/feature-rooms/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/presentation/models/UiImportConfirmation.kt
+++ b/shared/feature-rooms/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/presentation/models/UiImportConfirmation.kt
@@ -1,12 +1,9 @@
 package dev.nonoxy.residetrack.feature.rooms.presentation.models
 
-/**
- * Counts shown in the import confirmation dialog. Both the incoming backup and the data about to be
- * destroyed are exposed so the user sees the full consequence of a destructive replace-all restore.
- */
 data class UiImportConfirmation(
     val roomCount: Int,
     val studentCount: Int,
+    // current* = data the replace-all will destroy; shown so the user sees the full consequence.
     val currentRoomCount: Int,
     val currentStudentCount: Int,
 )

--- a/shared/feature-rooms/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/presentation/models/UiImportConfirmation.kt
+++ b/shared/feature-rooms/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/presentation/models/UiImportConfirmation.kt
@@ -1,7 +1,12 @@
 package dev.nonoxy.residetrack.feature.rooms.presentation.models
 
-/** Counts shown in the import confirmation dialog so the user sees what they are about to restore. */
+/**
+ * Counts shown in the import confirmation dialog. Both the incoming backup and the data about to be
+ * destroyed are exposed so the user sees the full consequence of a destructive replace-all restore.
+ */
 data class UiImportConfirmation(
     val roomCount: Int,
     val studentCount: Int,
+    val currentRoomCount: Int,
+    val currentStudentCount: Int,
 )

--- a/shared/feature-rooms/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/presentation/models/UiImportConfirmation.kt
+++ b/shared/feature-rooms/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/presentation/models/UiImportConfirmation.kt
@@ -1,0 +1,7 @@
+package dev.nonoxy.residetrack.feature.rooms.presentation.models
+
+/** Counts shown in the import confirmation dialog so the user sees what they are about to restore. */
+data class UiImportConfirmation(
+    val roomCount: Int,
+    val studentCount: Int,
+)

--- a/shared/feature-rooms/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/presentation/models/UiRoomsLabel.kt
+++ b/shared/feature-rooms/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/presentation/models/UiRoomsLabel.kt
@@ -3,4 +3,9 @@ package dev.nonoxy.residetrack.feature.rooms.presentation.models
 sealed interface UiRoomsLabel {
     data object NavigateToAddRoomScreen : UiRoomsLabel
     data class NavigateToRoomEditorExistingRoom(val roomId: String) : UiRoomsLabel
+
+    data class SaveBackupFile(val json: String, val suggestedName: String) : UiRoomsLabel
+    data object OpenBackupFile : UiRoomsLabel
+    data class ShowBackupSuccess(val message: String) : UiRoomsLabel
+    data class ShowBackupError(val message: String) : UiRoomsLabel
 }

--- a/shared/feature-rooms/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/presentation/models/UiRoomsState.kt
+++ b/shared/feature-rooms/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/presentation/models/UiRoomsState.kt
@@ -10,4 +10,5 @@ data class UiRoomsState(
     val totalPlaces: Int = 0,
     val availablePlaces: Int = 0,
     val roomsOnFloor: ImmutableMap<Int, ImmutableList<UiRoom>> = persistentMapOf(),
+    val importConfirmation: UiImportConfirmation? = null,
 )

--- a/shared/feature-rooms/presentation/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/rooms/presentation/mappers/UiRoomsStateMapperTest.kt
+++ b/shared/feature-rooms/presentation/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/rooms/presentation/mappers/UiRoomsStateMapperTest.kt
@@ -1,11 +1,14 @@
 package dev.nonoxy.residetrack.feature.rooms.presentation.mappers
 
+import dev.nonoxy.residetrack.core.backup.domain.model.Backup
+import dev.nonoxy.residetrack.core.backup.domain.model.BackupRoom
 import dev.nonoxy.residetrack.core.rooms.domain.model.Room
 import dev.nonoxy.residetrack.core.rooms.domain.model.Student
 import dev.nonoxy.residetrack.feature.rooms.api.store.RoomsStore
 import kotlinx.datetime.LocalDate
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class UiRoomsStateMapperTest {
@@ -69,5 +72,32 @@ class UiRoomsStateMapperTest {
         assertTrue(ui.isLoading)
         assertEquals(0, ui.totalPlaces)
         assertTrue(ui.roomsOnFloor.isEmpty())
+    }
+
+    @Test
+    fun `import confirmation carries both incoming and current-to-be-destroyed counts`() {
+        val state = RoomsStore.State(
+            roomsOnFloor = mapOf(
+                2 to listOf(
+                    room(id = 1, floor = 2, number = 21, beds = 4, students = listOf(student(1), student(2))),
+                ),
+                3 to listOf(
+                    room(id = 2, floor = 3, number = 31, beds = 3, students = listOf(student(3))),
+                ),
+            ),
+            importConfirmation = Backup(
+                rooms = listOf(
+                    BackupRoom(floorNumber = 5, roomNumber = 50, bedsCount = 2, students = emptyList()),
+                ),
+            ),
+        )
+
+        val confirmation = mapper.map(state).importConfirmation
+
+        assertNotNull(confirmation)
+        assertEquals(1, confirmation.roomCount) // incoming backup
+        assertEquals(0, confirmation.studentCount)
+        assertEquals(2, confirmation.currentRoomCount) // about to be wiped
+        assertEquals(3, confirmation.currentStudentCount)
     }
 }

--- a/shared/feature-rooms/presentation/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/rooms/presentation/mappers/UiRoomsStateMapperTest.kt
+++ b/shared/feature-rooms/presentation/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/rooms/presentation/mappers/UiRoomsStateMapperTest.kt
@@ -1,7 +1,7 @@
 package dev.nonoxy.residetrack.feature.rooms.presentation.mappers
 
-import dev.nonoxy.residetrack.core.rooms.models.Room
-import dev.nonoxy.residetrack.core.rooms.models.Student
+import dev.nonoxy.residetrack.core.rooms.domain.model.Room
+import dev.nonoxy.residetrack.core.rooms.domain.model.Student
 import dev.nonoxy.residetrack.feature.rooms.api.store.RoomsStore
 import kotlinx.datetime.LocalDate
 import kotlin.test.Test

--- a/shared/feature-rooms/presentation/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/rooms/presentation/mappers/UiRoomsStateMapperTest.kt
+++ b/shared/feature-rooms/presentation/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/rooms/presentation/mappers/UiRoomsStateMapperTest.kt
@@ -95,9 +95,9 @@ class UiRoomsStateMapperTest {
         val confirmation = mapper.map(state).importConfirmation
 
         assertNotNull(confirmation)
-        assertEquals(1, confirmation.roomCount) // incoming backup
+        assertEquals(1, confirmation.roomCount)
         assertEquals(0, confirmation.studentCount)
-        assertEquals(2, confirmation.currentRoomCount) // about to be wiped
+        assertEquals(2, confirmation.currentRoomCount)
         assertEquals(3, confirmation.currentStudentCount)
     }
 }

--- a/shared/feature-rooms/ui/build.gradle.kts
+++ b/shared/feature-rooms/ui/build.gradle.kts
@@ -1,4 +1,5 @@
 import extensions.androidLibraryConfig
+import extensions.androidMainDependencies
 import extensions.commonMainDependencies
 import extensions.implementations
 
@@ -15,5 +16,11 @@ androidLibraryConfig {
 commonMainDependencies {
     implementations(
         libs.kotlin.immutableCollections,
+    )
+}
+
+androidMainDependencies {
+    implementations(
+        libs.androidx.activity.compose,
     )
 }

--- a/shared/feature-rooms/ui/src/androidMain/kotlin/dev/nonoxy/residetrack/feature/rooms/ui/BackupFilePicker.android.kt
+++ b/shared/feature-rooms/ui/src/androidMain/kotlin/dev/nonoxy/residetrack/feature/rooms/ui/BackupFilePicker.android.kt
@@ -6,8 +6,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @Composable
 internal actual fun rememberBackupFilePicker(
@@ -15,7 +20,9 @@ internal actual fun rememberBackupFilePicker(
     onExportCompleted: (Boolean) -> Unit,
 ): BackupFilePicker {
     val context = LocalContext.current
-    var pendingJson by remember { mutableStateOf<String?>(null) }
+    val scope = rememberCoroutineScope()
+    // rememberSaveable so a destination chosen after process death still finds its JSON to write.
+    var pendingJson by rememberSaveable { mutableStateOf<String?>(null) }
 
     val createLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.CreateDocument("application/json"),
@@ -24,11 +31,15 @@ internal actual fun rememberBackupFilePicker(
         pendingJson = null
         // Null uri means the user cancelled — stay silent. Only report once a destination was chosen.
         if (uri != null && json != null) {
-            val written = runCatching {
-                val stream = context.contentResolver.openOutputStream(uri) ?: error("no output stream")
-                stream.use { it.write(json.encodeToByteArray()) }
-            }.isSuccess
-            onExportCompleted(written)
+            scope.launch {
+                val written = withContext(Dispatchers.IO) {
+                    runCatching {
+                        val stream = context.contentResolver.openOutputStream(uri) ?: error("no output stream")
+                        stream.use { it.write(json.encodeToByteArray()) }
+                    }.isSuccess
+                }
+                onExportCompleted(written)
+            }
         }
     }
 
@@ -36,23 +47,49 @@ internal actual fun rememberBackupFilePicker(
         contract = ActivityResultContracts.OpenDocument(),
     ) { uri ->
         if (uri != null) {
-            val json = runCatching {
-                context.contentResolver.openInputStream(uri)?.bufferedReader()?.use { it.readText() }
-            }.getOrNull()
-            if (json != null) onImported(json)
+            scope.launch {
+                val json = withContext(Dispatchers.IO) {
+                    runCatching {
+                        context.contentResolver.openInputStream(uri)?.bufferedReader()?.use { it.readText() }
+                    }.getOrNull()
+                }
+                if (json != null) onImported(json)
+            }
         }
     }
 
     return remember {
-        object : BackupFilePicker {
-            override fun launchSave(json: String, suggestedName: String) {
+        AndroidBackupFilePicker(
+            launchCreate = { name, json ->
                 pendingJson = json
-                createLauncher.launch(suggestedName)
-            }
+                createLauncher.launch(name)
+            },
+            launchOpen = { openLauncher.launch(arrayOf("application/json")) },
+            onExportCompleted = onExportCompleted,
+            clearPending = { pendingJson = null },
+        )
+    }
+}
 
-            override fun launchOpen() {
-                openLauncher.launch(arrayOf("application/json"))
+private class AndroidBackupFilePicker(
+    private val launchCreate: (name: String, json: String) -> Unit,
+    private val launchOpen: () -> Unit,
+    private val onExportCompleted: (Boolean) -> Unit,
+    private val clearPending: () -> Unit,
+) : BackupFilePicker {
+
+    override fun launchSave(json: String, suggestedName: String) {
+        // launch() throws ActivityNotFoundException when no document provider is available
+        // (locked-down OEM / work profile). Report the failure instead of crashing.
+        runCatching { launchCreate(suggestedName, json) }
+            .onFailure {
+                clearPending()
+                onExportCompleted(false)
             }
-        }
+    }
+
+    override fun launchOpen() {
+        // No completion signal on the open path — a missing provider just means no picker appears.
+        runCatching { launchOpen() }
     }
 }

--- a/shared/feature-rooms/ui/src/androidMain/kotlin/dev/nonoxy/residetrack/feature/rooms/ui/BackupFilePicker.android.kt
+++ b/shared/feature-rooms/ui/src/androidMain/kotlin/dev/nonoxy/residetrack/feature/rooms/ui/BackupFilePicker.android.kt
@@ -1,0 +1,58 @@
+package dev.nonoxy.residetrack.feature.rooms.ui
+
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+
+@Composable
+internal actual fun rememberBackupFilePicker(
+    onImported: (String) -> Unit,
+    onExportCompleted: (Boolean) -> Unit,
+): BackupFilePicker {
+    val context = LocalContext.current
+    var pendingJson by remember { mutableStateOf<String?>(null) }
+
+    val createLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.CreateDocument("application/json"),
+    ) { uri ->
+        val json = pendingJson
+        pendingJson = null
+        // Null uri means the user cancelled — stay silent. Only report once a destination was chosen.
+        if (uri != null && json != null) {
+            val written = runCatching {
+                val stream = context.contentResolver.openOutputStream(uri) ?: error("no output stream")
+                stream.use { it.write(json.encodeToByteArray()) }
+            }.isSuccess
+            onExportCompleted(written)
+        }
+    }
+
+    val openLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.OpenDocument(),
+    ) { uri ->
+        if (uri != null) {
+            val json = runCatching {
+                context.contentResolver.openInputStream(uri)?.bufferedReader()?.use { it.readText() }
+            }.getOrNull()
+            if (json != null) onImported(json)
+        }
+    }
+
+    return remember {
+        object : BackupFilePicker {
+            override fun launchSave(json: String, suggestedName: String) {
+                pendingJson = json
+                createLauncher.launch(suggestedName)
+            }
+
+            override fun launchOpen() {
+                openLauncher.launch(arrayOf("application/json"))
+            }
+        }
+    }
+}

--- a/shared/feature-rooms/ui/src/androidMain/kotlin/dev/nonoxy/residetrack/feature/rooms/ui/BackupFilePicker.android.kt
+++ b/shared/feature-rooms/ui/src/androidMain/kotlin/dev/nonoxy/residetrack/feature/rooms/ui/BackupFilePicker.android.kt
@@ -29,7 +29,7 @@ internal actual fun rememberBackupFilePicker(
     ) { uri ->
         val json = pendingJson
         pendingJson = null
-        // Null uri means the user cancelled — stay silent. Only report once a destination was chosen.
+        // Null uri = cancelled; report only once a destination was chosen.
         if (uri != null && json != null) {
             scope.launch {
                 val written = withContext(Dispatchers.IO) {

--- a/shared/feature-rooms/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/ui/BackupFilePicker.kt
+++ b/shared/feature-rooms/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/ui/BackupFilePicker.kt
@@ -1,0 +1,22 @@
+package dev.nonoxy.residetrack.feature.rooms.ui
+
+import androidx.compose.runtime.Composable
+
+/**
+ * Thin platform conduit for the system file picker. Holds zero domain logic: it only launches the
+ * picker and streams bytes ↔ String. Everything else (serialize, validate, persist) lives in
+ * core-backup; the screen wires these callbacks to the view-model.
+ */
+internal interface BackupFilePicker {
+    /** Lets the user pick a destination and writes [json], then reports success via onExportCompleted. */
+    fun launchSave(json: String, suggestedName: String)
+
+    /** Lets the user pick a backup file; its contents are delivered via onImported. */
+    fun launchOpen()
+}
+
+@Composable
+internal expect fun rememberBackupFilePicker(
+    onImported: (String) -> Unit,
+    onExportCompleted: (Boolean) -> Unit,
+): BackupFilePicker

--- a/shared/feature-rooms/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/ui/RoomsScreen.kt
+++ b/shared/feature-rooms/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/ui/RoomsScreen.kt
@@ -46,6 +46,8 @@ internal fun RoomsScreen(
         ImportConfirmDialog(
             roomCount = confirmation.roomCount,
             studentCount = confirmation.studentCount,
+            currentRoomCount = confirmation.currentRoomCount,
+            currentStudentCount = confirmation.currentStudentCount,
             onConfirm = viewModel::onRestoreConfirm,
             onDismiss = viewModel::onRestoreCancel,
         )

--- a/shared/feature-rooms/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/ui/RoomsScreen.kt
+++ b/shared/feature-rooms/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/ui/RoomsScreen.kt
@@ -1,13 +1,28 @@
 package dev.nonoxy.residetrack.feature.rooms.ui
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import dev.nonoxy.residetrack.core.navigation.bottombar.LocalFloatingBottomBarInset
 import dev.nonoxy.residetrack.feature.rooms.presentation.RoomsViewModel
 import dev.nonoxy.residetrack.feature.rooms.presentation.models.UiRoomsLabel
+import dev.nonoxy.residetrack.feature.rooms.ui.views.ImportConfirmDialog
 import dev.nonoxy.residetrack.feature.rooms.ui.views.RoomsScreenDetails
+import dev.nonoxy.residetrack.common.ui.common.snackbar.ResideTrackErrorSnackbar
+import dev.nonoxy.residetrack.common.ui.common.snackbar.ResideTrackSnackbar
+import dev.nonoxy.residetrack.common.ui.common.snackbar.ResideTrackSuccessSnackbar
+import dev.nonoxy.residetrack.common.ui.common.snackbar.SnackbarType
 import dev.nonoxy.residetrack.common.ui.common.utils.CollectFlow
 import org.koin.compose.viewmodel.koinViewModel
 
@@ -19,19 +34,71 @@ internal fun RoomsScreen(
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
 
+    val snackbarHostState = remember { SnackbarHostState() }
+    var snackbarType by rememberSaveable { mutableStateOf(SnackbarType.INFO) }
+
+    val filePicker = rememberBackupFilePicker(
+        onImported = viewModel::onBackupFileLoaded,
+        onExportCompleted = viewModel::onExportCompleted,
+    )
+
+    state.importConfirmation?.let { confirmation ->
+        ImportConfirmDialog(
+            roomCount = confirmation.roomCount,
+            studentCount = confirmation.studentCount,
+            onConfirm = viewModel::onRestoreConfirm,
+            onDismiss = viewModel::onRestoreCancel,
+        )
+    }
+
     viewModel.label.CollectFlow { label ->
         when (label) {
             UiRoomsLabel.NavigateToAddRoomScreen -> onNavigateToAddRoomScreen()
             is UiRoomsLabel.NavigateToRoomEditorExistingRoom ->
                 onNavigateToRoomEditorExistingRoom(label.roomId)
+
+            is UiRoomsLabel.SaveBackupFile ->
+                filePicker.launchSave(json = label.json, suggestedName = label.suggestedName)
+
+            UiRoomsLabel.OpenBackupFile -> filePicker.launchOpen()
+
+            is UiRoomsLabel.ShowBackupSuccess -> {
+                snackbarType = SnackbarType.SUCCESS
+                snackbarHostState.currentSnackbarData?.dismiss()
+                snackbarHostState.showSnackbar(message = label.message, withDismissAction = true)
+            }
+
+            is UiRoomsLabel.ShowBackupError -> {
+                snackbarType = SnackbarType.ERROR
+                snackbarHostState.currentSnackbarData?.dismiss()
+                snackbarHostState.showSnackbar(message = label.message, withDismissAction = true)
+            }
         }
     }
 
-    RoomsScreenDetails(
-        state = state,
-        onRoomClick = viewModel::onRoomClick,
-        onAddRoomClick = viewModel::onAddRoomClick,
-        onRetryClick = viewModel::onRetryClick,
-        modifier = Modifier.fillMaxSize()
-    )
+    Box(modifier = Modifier.fillMaxSize()) {
+        RoomsScreenDetails(
+            state = state,
+            onRoomClick = viewModel::onRoomClick,
+            onAddRoomClick = viewModel::onAddRoomClick,
+            onRetryClick = viewModel::onRetryClick,
+            onBackupExportClick = viewModel::onExportClick,
+            onBackupImportClick = viewModel::onImportClick,
+            modifier = Modifier.fillMaxSize(),
+        )
+
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(bottom = LocalFloatingBottomBarInset.current),
+            snackbar = { snackbarData ->
+                when (snackbarType) {
+                    SnackbarType.SUCCESS -> ResideTrackSuccessSnackbar(snackbarData = snackbarData)
+                    SnackbarType.ERROR -> ResideTrackErrorSnackbar(snackbarData = snackbarData)
+                    else -> ResideTrackSnackbar(snackbarData = snackbarData)
+                }
+            },
+        )
+    }
 }

--- a/shared/feature-rooms/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/ui/views/BackupMenu.kt
+++ b/shared/feature-rooms/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/ui/views/BackupMenu.kt
@@ -1,0 +1,51 @@
+package dev.nonoxy.residetrack.feature.rooms.ui.views
+
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import dev.icerock.moko.resources.compose.stringResource
+import dev.nonoxy.residetrack.common.ui.theme.ResideTrackTheme
+import dev.nonoxy.residetrack.res.MR
+
+@Composable
+internal fun BackupMenu(
+    expanded: Boolean,
+    onDismiss: () -> Unit,
+    onExportClick: () -> Unit,
+    onImportClick: () -> Unit,
+) {
+    DropdownMenu(
+        expanded = expanded,
+        onDismissRequest = onDismiss,
+        containerColor = ResideTrackTheme.colors.surface,
+        shape = ResideTrackTheme.shapes.cornerRadius12,
+    ) {
+        DropdownMenuItem(
+            text = {
+                Text(
+                    text = stringResource(MR.strings.backup_menu_export),
+                    style = ResideTrackTheme.typography.paragraph,
+                    color = ResideTrackTheme.colors.textPrimary,
+                )
+            },
+            onClick = {
+                onDismiss()
+                onExportClick()
+            },
+        )
+        DropdownMenuItem(
+            text = {
+                Text(
+                    text = stringResource(MR.strings.backup_menu_import),
+                    style = ResideTrackTheme.typography.paragraph,
+                    color = ResideTrackTheme.colors.textPrimary,
+                )
+            },
+            onClick = {
+                onDismiss()
+                onImportClick()
+            },
+        )
+    }
+}

--- a/shared/feature-rooms/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/ui/views/BackupMenu.kt
+++ b/shared/feature-rooms/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/ui/views/BackupMenu.kt
@@ -2,8 +2,12 @@ package dev.nonoxy.residetrack.feature.rooms.ui.views
 
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import dev.icerock.moko.resources.ImageResource
+import dev.icerock.moko.resources.compose.painterResource
 import dev.icerock.moko.resources.compose.stringResource
 import dev.nonoxy.residetrack.common.ui.theme.ResideTrackTheme
 import dev.nonoxy.residetrack.res.MR
@@ -21,31 +25,50 @@ internal fun BackupMenu(
         containerColor = ResideTrackTheme.colors.surface,
         shape = ResideTrackTheme.shapes.cornerRadius12,
     ) {
-        DropdownMenuItem(
-            text = {
-                Text(
-                    text = stringResource(MR.strings.backup_menu_export),
-                    style = ResideTrackTheme.typography.paragraph,
-                    color = ResideTrackTheme.colors.textPrimary,
-                )
-            },
+        BackupMenuItem(
+            text = stringResource(MR.strings.backup_menu_export),
+            icon = MR.images.ic_backup_export,
+            color = ResideTrackTheme.colors.textPrimary,
             onClick = {
                 onDismiss()
                 onExportClick()
             },
         )
-        DropdownMenuItem(
-            text = {
-                Text(
-                    text = stringResource(MR.strings.backup_menu_import),
-                    style = ResideTrackTheme.typography.paragraph,
-                    color = ResideTrackTheme.colors.textPrimary,
-                )
-            },
+        // Restore is destructive (replace-all), so it reads in the error colour before it's tapped.
+        BackupMenuItem(
+            text = stringResource(MR.strings.backup_menu_import),
+            icon = MR.images.ic_backup_restore,
+            color = ResideTrackTheme.colors.textError,
             onClick = {
                 onDismiss()
                 onImportClick()
             },
         )
     }
+}
+
+@Composable
+private fun BackupMenuItem(
+    text: String,
+    icon: ImageResource,
+    color: Color,
+    onClick: () -> Unit,
+) {
+    DropdownMenuItem(
+        text = {
+            Text(
+                text = text,
+                style = ResideTrackTheme.typography.paragraph,
+                color = color,
+            )
+        },
+        leadingIcon = {
+            Icon(
+                painter = painterResource(icon),
+                contentDescription = null,
+                tint = color,
+            )
+        },
+        onClick = onClick,
+    )
 }

--- a/shared/feature-rooms/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/ui/views/ImportConfirmDialog.kt
+++ b/shared/feature-rooms/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/ui/views/ImportConfirmDialog.kt
@@ -1,0 +1,57 @@
+package dev.nonoxy.residetrack.feature.rooms.ui.views
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import dev.icerock.moko.resources.compose.stringResource
+import dev.nonoxy.residetrack.common.ui.theme.ResideTrackTheme
+import dev.nonoxy.residetrack.common.ui.theme.padding_size_8
+import dev.nonoxy.residetrack.res.MR
+
+@Composable
+internal fun ImportConfirmDialog(
+    roomCount: Int,
+    studentCount: Int,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        containerColor = ResideTrackTheme.colors.surface,
+        titleContentColor = ResideTrackTheme.colors.textPrimary,
+        textContentColor = ResideTrackTheme.colors.textBody,
+        title = {
+            Text(text = stringResource(MR.strings.backup_import_dialog_title))
+        },
+        text = {
+            Column {
+                Text(text = stringResource(MR.strings.backup_import_dialog_message))
+                Text(
+                    modifier = Modifier.padding(top = padding_size_8),
+                    text = stringResource(MR.strings.backup_import_dialog_counts, roomCount, studentCount),
+                    color = ResideTrackTheme.colors.textCaption,
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(
+                    text = stringResource(MR.strings.backup_import_confirm),
+                    color = ResideTrackTheme.colors.textError,
+                )
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(
+                    text = stringResource(MR.strings.backup_cancel),
+                    color = ResideTrackTheme.colors.textPrimary,
+                )
+            }
+        },
+    )
+}

--- a/shared/feature-rooms/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/ui/views/ImportConfirmDialog.kt
+++ b/shared/feature-rooms/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/ui/views/ImportConfirmDialog.kt
@@ -16,6 +16,8 @@ import dev.nonoxy.residetrack.res.MR
 internal fun ImportConfirmDialog(
     roomCount: Int,
     studentCount: Int,
+    currentRoomCount: Int,
+    currentStudentCount: Int,
     onConfirm: () -> Unit,
     onDismiss: () -> Unit,
 ) {
@@ -30,9 +32,23 @@ internal fun ImportConfirmDialog(
         text = {
             Column {
                 Text(text = stringResource(MR.strings.backup_import_dialog_message))
+                // "Сейчас" in error colour makes the data about to be destroyed the loud part;
+                // "Станет" shows what replaces it, so the magnitude of the loss is explicit.
                 Text(
                     modifier = Modifier.padding(top = padding_size_8),
-                    text = stringResource(MR.strings.backup_import_dialog_counts, roomCount, studentCount),
+                    text = stringResource(
+                        MR.strings.backup_import_current,
+                        stringResource(MR.plurals.backup_rooms_count, currentRoomCount, currentRoomCount),
+                        stringResource(MR.plurals.backup_students_count, currentStudentCount, currentStudentCount),
+                    ),
+                    color = ResideTrackTheme.colors.textError,
+                )
+                Text(
+                    text = stringResource(
+                        MR.strings.backup_import_after,
+                        stringResource(MR.plurals.backup_rooms_count, roomCount, roomCount),
+                        stringResource(MR.plurals.backup_students_count, studentCount, studentCount),
+                    ),
                     color = ResideTrackTheme.colors.textCaption,
                 )
             }

--- a/shared/feature-rooms/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/ui/views/RoomsScreenDetails.kt
+++ b/shared/feature-rooms/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/ui/views/RoomsScreenDetails.kt
@@ -30,6 +30,8 @@ internal fun RoomsScreenDetails(
     onRoomClick: (Long) -> Unit,
     onAddRoomClick: () -> Unit,
     onRetryClick: () -> Unit,
+    onBackupExportClick: () -> Unit,
+    onBackupImportClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     ShowStateData(
@@ -47,7 +49,9 @@ internal fun RoomsScreenDetails(
                 modifier = Modifier.padding(horizontal = padding_size_16),
                 totalPlaces = currentState.totalPlaces,
                 availablePlaces = currentState.availablePlaces,
-                onAddRoomClick = onAddRoomClick
+                onAddRoomClick = onAddRoomClick,
+                onBackupExportClick = onBackupExportClick,
+                onBackupImportClick = onBackupImportClick,
             )
 
             if (currentState.roomsOnFloor.isEmpty()) {
@@ -127,6 +131,8 @@ private fun Preview() {
             onRoomClick = {},
             onAddRoomClick = {},
             onRetryClick = {},
+            onBackupExportClick = {},
+            onBackupImportClick = {},
             modifier = Modifier.fillMaxSize()
         )
     }

--- a/shared/feature-rooms/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/ui/views/RoomsTopBar.kt
+++ b/shared/feature-rooms/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/ui/views/RoomsTopBar.kt
@@ -1,5 +1,6 @@
 package dev.nonoxy.residetrack.feature.rooms.ui.views
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -9,6 +10,10 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarColors
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import dev.nonoxy.residetrack.common.ui.theme.ResideTrackTheme
 import dev.icerock.moko.resources.compose.painterResource
@@ -22,6 +27,8 @@ internal fun RoomsTopBar(
     totalPlaces: Int,
     availablePlaces: Int,
     onAddRoomClick: () -> Unit,
+    onBackupExportClick: () -> Unit,
+    onBackupImportClick: () -> Unit,
     modifier: Modifier = Modifier,
     colors: TopAppBarColors = TopAppBarDefaults.centerAlignedTopAppBarColors(
         containerColor = ResideTrackTheme.colors.background,
@@ -38,6 +45,22 @@ internal fun RoomsTopBar(
                 Icon(
                     painter = painterResource(MR.images.ic_add),
                     contentDescription = stringResource(MR.strings.rooms_add_content_description)
+                )
+            }
+
+            Box {
+                var menuExpanded by remember { mutableStateOf(false) }
+                IconButton(onClick = { menuExpanded = true }) {
+                    Icon(
+                        painter = painterResource(MR.images.ic_more),
+                        contentDescription = stringResource(MR.strings.backup_menu_content_description)
+                    )
+                }
+                BackupMenu(
+                    expanded = menuExpanded,
+                    onDismiss = { menuExpanded = false },
+                    onExportClick = onBackupExportClick,
+                    onImportClick = onBackupImportClick,
                 )
             }
         },
@@ -73,7 +96,9 @@ private fun Preview() {
         RoomsTopBar(
             totalPlaces = 617,
             availablePlaces = 613,
-            onAddRoomClick = {}
+            onAddRoomClick = {},
+            onBackupExportClick = {},
+            onBackupImportClick = {},
         )
     }
 }

--- a/shared/feature-rooms/ui/src/iosMain/kotlin/dev/nonoxy/residetrack/feature/rooms/ui/BackupFilePicker.ios.kt
+++ b/shared/feature-rooms/ui/src/iosMain/kotlin/dev/nonoxy/residetrack/feature/rooms/ui/BackupFilePicker.ios.kt
@@ -2,17 +2,26 @@ package dev.nonoxy.residetrack.feature.rooms.ui
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.usePinned
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import platform.Foundation.NSData
+import platform.Foundation.NSFileManager
 import platform.Foundation.NSString
 import platform.Foundation.NSTemporaryDirectory
 import platform.Foundation.NSURL
 import platform.Foundation.NSUTF8StringEncoding
-import platform.Foundation.stringByAppendingPathComponent
+import platform.Foundation.create
 import platform.Foundation.stringWithContentsOfURL
 import platform.Foundation.writeToURL
 import platform.UIKit.UIApplication
-import platform.UIKit.UIDocumentPickerViewController
 import platform.UIKit.UIDocumentPickerDelegateProtocol
+import platform.UIKit.UIDocumentPickerViewController
 import platform.UniformTypeIdentifiers.UTTypeJSON
 import platform.darwin.NSObject
 
@@ -20,10 +29,14 @@ import platform.darwin.NSObject
 internal actual fun rememberBackupFilePicker(
     onImported: (String) -> Unit,
     onExportCompleted: (Boolean) -> Unit,
-): BackupFilePicker = remember { IosBackupFilePicker(onImported, onExportCompleted) }
+): BackupFilePicker {
+    val scope = rememberCoroutineScope()
+    return remember { IosBackupFilePicker(scope, onImported, onExportCompleted) }
+}
 
 @OptIn(ExperimentalForeignApi::class)
 private class IosBackupFilePicker(
+    private val scope: CoroutineScope,
     private val onImported: (String) -> Unit,
     private val onExportCompleted: (Boolean) -> Unit,
 ) : BackupFilePicker {
@@ -32,20 +45,31 @@ private class IosBackupFilePicker(
     private var delegate: PickerDelegate? = null
 
     override fun launchSave(json: String, suggestedName: String) {
-        val path = (NSTemporaryDirectory() as NSString).stringByAppendingPathComponent(suggestedName)
-        val url = NSURL.fileURLWithPath(path)
-        val written = (json as NSString).writeToURL(
-            url,
-            atomically = true,
-            encoding = NSUTF8StringEncoding,
-            error = null
-        )
-        if (!written) {
-            onExportCompleted(false)
-            return
+        scope.launch {
+            val tempUrl = withContext(Dispatchers.Default) { writeTempFile(json, suggestedName) }
+            if (tempUrl == null) {
+                onExportCompleted(false)
+                return@launch
+            }
+            // Resumed on the main dispatcher — UIKit presentation must stay on the main thread.
+            val picker = UIDocumentPickerViewController(forExportingURLs = listOf(tempUrl))
+            present(
+                picker,
+                onPicked = { urls ->
+                    scope.launch {
+                        val saved = withContext(Dispatchers.Default) {
+                            val exists = (urls.firstOrNull() as? NSURL)?.let(::destinationExists) ?: false
+                            removeTempFile(tempUrl)
+                            exists
+                        }
+                        onExportCompleted(saved)
+                    }
+                },
+                onCancelled = {
+                    scope.launch { withContext(Dispatchers.Default) { removeTempFile(tempUrl) } }
+                },
+            )
         }
-        val picker = UIDocumentPickerViewController(forExportingURLs = listOf(url))
-        present(picker, onPicked = { onExportCompleted(true) }, onCancelled = {})
     }
 
     override fun launchOpen() {
@@ -54,13 +78,54 @@ private class IosBackupFilePicker(
             picker,
             onPicked = { urls ->
                 val url = urls.firstOrNull() as? NSURL ?: return@present
-                val accessed = url.startAccessingSecurityScopedResource()
-                val content = NSString.stringWithContentsOfURL(url, NSUTF8StringEncoding, null)
-                if (accessed) url.stopAccessingSecurityScopedResource()
-                if (content != null) onImported(content)
+                scope.launch {
+                    val content = withContext(Dispatchers.Default) { readSecurityScoped(url) }
+                    if (content != null) onImported(content)
+                }
             },
             onCancelled = {},
         )
+    }
+
+    /** Writes [json] to a temp file and returns its URL, or null if the write failed. */
+    private fun writeTempFile(json: String, name: String): NSURL? {
+        val dir = NSURL.fileURLWithPath(NSTemporaryDirectory(), isDirectory = true)
+        val url = dir.URLByAppendingPathComponent(name) ?: return null
+        val bytes = json.encodeToByteArray()
+        if (bytes.isEmpty()) return null
+        val written = bytes.usePinned { pinned ->
+            NSData.create(bytes = pinned.addressOf(0), length = bytes.size.toULong())
+                .writeToURL(url, atomically = true)
+        }
+        return if (written) url else null
+    }
+
+    private fun removeTempFile(url: NSURL) {
+        NSFileManager.defaultManager.removeItemAtURL(url, error = null)
+    }
+
+    /**
+     * Best-effort confirmation that the export actually landed: `forExportingURLs` reports the
+     * destination URL after the system copies the file, so we verify the file exists there rather
+     * than trusting "the user tapped a folder".
+     */
+    private fun destinationExists(url: NSURL): Boolean {
+        val accessed = url.startAccessingSecurityScopedResource()
+        return try {
+            val path = url.path
+            path != null && NSFileManager.defaultManager.fileExistsAtPath(path)
+        } finally {
+            if (accessed) url.stopAccessingSecurityScopedResource()
+        }
+    }
+
+    private fun readSecurityScoped(url: NSURL): String? {
+        val accessed = url.startAccessingSecurityScopedResource()
+        return try {
+            NSString.stringWithContentsOfURL(url, NSUTF8StringEncoding, error = null)
+        } finally {
+            if (accessed) url.stopAccessingSecurityScopedResource()
+        }
     }
 
     private fun present(

--- a/shared/feature-rooms/ui/src/iosMain/kotlin/dev/nonoxy/residetrack/feature/rooms/ui/BackupFilePicker.ios.kt
+++ b/shared/feature-rooms/ui/src/iosMain/kotlin/dev/nonoxy/residetrack/feature/rooms/ui/BackupFilePicker.ios.kt
@@ -1,0 +1,103 @@
+package dev.nonoxy.residetrack.feature.rooms.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.Foundation.NSString
+import platform.Foundation.NSTemporaryDirectory
+import platform.Foundation.NSURL
+import platform.Foundation.NSUTF8StringEncoding
+import platform.Foundation.stringByAppendingPathComponent
+import platform.Foundation.stringWithContentsOfURL
+import platform.Foundation.writeToURL
+import platform.UIKit.UIApplication
+import platform.UIKit.UIDocumentPickerViewController
+import platform.UIKit.UIDocumentPickerDelegateProtocol
+import platform.UniformTypeIdentifiers.UTTypeJSON
+import platform.darwin.NSObject
+
+@Composable
+internal actual fun rememberBackupFilePicker(
+    onImported: (String) -> Unit,
+    onExportCompleted: (Boolean) -> Unit,
+): BackupFilePicker = remember { IosBackupFilePicker(onImported, onExportCompleted) }
+
+@OptIn(ExperimentalForeignApi::class)
+private class IosBackupFilePicker(
+    private val onImported: (String) -> Unit,
+    private val onExportCompleted: (Boolean) -> Unit,
+) : BackupFilePicker {
+
+    // Strong ref so the delegate survives while the picker is on screen.
+    private var delegate: PickerDelegate? = null
+
+    override fun launchSave(json: String, suggestedName: String) {
+        val path = (NSTemporaryDirectory() as NSString).stringByAppendingPathComponent(suggestedName)
+        val url = NSURL.fileURLWithPath(path)
+        val written = (json as NSString).writeToURL(
+            url,
+            atomically = true,
+            encoding = NSUTF8StringEncoding,
+            error = null
+        )
+        if (!written) {
+            onExportCompleted(false)
+            return
+        }
+        val picker = UIDocumentPickerViewController(forExportingURLs = listOf(url))
+        present(picker, onPicked = { onExportCompleted(true) }, onCancelled = {})
+    }
+
+    override fun launchOpen() {
+        val picker = UIDocumentPickerViewController(forOpeningContentTypes = listOf(UTTypeJSON))
+        present(
+            picker,
+            onPicked = { urls ->
+                val url = urls.firstOrNull() as? NSURL ?: return@present
+                val accessed = url.startAccessingSecurityScopedResource()
+                val content = NSString.stringWithContentsOfURL(url, NSUTF8StringEncoding, null)
+                if (accessed) url.stopAccessingSecurityScopedResource()
+                if (content != null) onImported(content)
+            },
+            onCancelled = {},
+        )
+    }
+
+    private fun present(
+        picker: UIDocumentPickerViewController,
+        onPicked: (List<*>) -> Unit,
+        onCancelled: () -> Unit,
+    ) {
+        val pickerDelegate = PickerDelegate(
+            onPickedUrls = { urls ->
+                delegate = null
+                onPicked(urls)
+            },
+            onCancelledPick = {
+                delegate = null
+                onCancelled()
+            },
+        )
+        delegate = pickerDelegate
+        picker.delegate = pickerDelegate
+        val root = UIApplication.sharedApplication.keyWindow?.rootViewController
+        root?.presentViewController(picker, animated = true, completion = null)
+    }
+}
+
+private class PickerDelegate(
+    private val onPickedUrls: (List<*>) -> Unit,
+    private val onCancelledPick: () -> Unit,
+) : NSObject(), UIDocumentPickerDelegateProtocol {
+
+    override fun documentPicker(
+        controller: UIDocumentPickerViewController,
+        didPickDocumentsAtURLs: List<*>,
+    ) {
+        onPickedUrls(didPickDocumentsAtURLs)
+    }
+
+    override fun documentPickerWasCancelled(controller: UIDocumentPickerViewController) {
+        onCancelledPick()
+    }
+}

--- a/shared/feature-rooms/ui/src/iosMain/kotlin/dev/nonoxy/residetrack/feature/rooms/ui/BackupFilePicker.ios.kt
+++ b/shared/feature-rooms/ui/src/iosMain/kotlin/dev/nonoxy/residetrack/feature/rooms/ui/BackupFilePicker.ios.kt
@@ -87,7 +87,6 @@ private class IosBackupFilePicker(
         )
     }
 
-    /** Writes [json] to a temp file and returns its URL, or null if the write failed. */
     private fun writeTempFile(json: String, name: String): NSURL? {
         val dir = NSURL.fileURLWithPath(NSTemporaryDirectory(), isDirectory = true)
         val url = dir.URLByAppendingPathComponent(name) ?: return null

--- a/shared/feature-upcoming/api/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/upcoming/api/models/UpcomingItem.kt
+++ b/shared/feature-upcoming/api/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/upcoming/api/models/UpcomingItem.kt
@@ -1,6 +1,6 @@
 package dev.nonoxy.residetrack.feature.upcoming.api.models
 
-import dev.nonoxy.residetrack.core.rooms.upcoming.UpcomingBucket
+import dev.nonoxy.residetrack.core.rooms.domain.upcoming.UpcomingBucket
 import kotlinx.datetime.LocalDate
 
 data class UpcomingItem(

--- a/shared/feature-upcoming/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/upcoming/impl/domain/UpcomingExecutor.kt
+++ b/shared/feature-upcoming/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/upcoming/impl/domain/UpcomingExecutor.kt
@@ -2,7 +2,7 @@ package dev.nonoxy.residetrack.feature.upcoming.impl.domain
 
 import dev.nonoxy.residetrack.common.utils.currentLocalDate
 import dev.nonoxy.residetrack.core.mvikotlin.BaseExecutor
-import dev.nonoxy.residetrack.core.rooms.repository.RoomsRepository
+import dev.nonoxy.residetrack.core.rooms.domain.repository.RoomsRepository
 import dev.nonoxy.residetrack.feature.upcoming.api.store.UpcomingStore.Intent
 import dev.nonoxy.residetrack.feature.upcoming.api.store.UpcomingStore.Label
 import dev.nonoxy.residetrack.feature.upcoming.api.store.UpcomingStore.State

--- a/shared/feature-upcoming/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/upcoming/impl/domain/UpcomingMapper.kt
+++ b/shared/feature-upcoming/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/upcoming/impl/domain/UpcomingMapper.kt
@@ -1,7 +1,7 @@
 package dev.nonoxy.residetrack.feature.upcoming.impl.domain
 
-import dev.nonoxy.residetrack.core.rooms.models.Room
-import dev.nonoxy.residetrack.core.rooms.upcoming.UpcomingCheckouts
+import dev.nonoxy.residetrack.core.rooms.domain.model.Room
+import dev.nonoxy.residetrack.core.rooms.domain.upcoming.UpcomingCheckouts
 import dev.nonoxy.residetrack.feature.upcoming.api.models.UpcomingItem
 import kotlinx.datetime.LocalDate
 

--- a/shared/feature-upcoming/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/upcoming/impl/domain/UpcomingStoreFactory.kt
+++ b/shared/feature-upcoming/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/upcoming/impl/domain/UpcomingStoreFactory.kt
@@ -3,7 +3,7 @@ package dev.nonoxy.residetrack.feature.upcoming.impl.domain
 import com.arkivanov.mvikotlin.core.store.SimpleBootstrapper
 import com.arkivanov.mvikotlin.core.store.Store
 import com.arkivanov.mvikotlin.core.store.StoreFactory
-import dev.nonoxy.residetrack.core.rooms.repository.RoomsRepository
+import dev.nonoxy.residetrack.core.rooms.domain.repository.RoomsRepository
 import dev.nonoxy.residetrack.feature.upcoming.api.models.UpcomingItem
 import dev.nonoxy.residetrack.feature.upcoming.api.store.UpcomingStore
 import dev.nonoxy.residetrack.feature.upcoming.api.store.UpcomingStore.Intent

--- a/shared/feature-upcoming/impl/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/upcoming/impl/domain/UpcomingMapperTest.kt
+++ b/shared/feature-upcoming/impl/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/upcoming/impl/domain/UpcomingMapperTest.kt
@@ -1,8 +1,8 @@
 package dev.nonoxy.residetrack.feature.upcoming.impl.domain
 
-import dev.nonoxy.residetrack.core.rooms.models.Room
-import dev.nonoxy.residetrack.core.rooms.models.Student
-import dev.nonoxy.residetrack.core.rooms.upcoming.UpcomingBucket
+import dev.nonoxy.residetrack.core.rooms.domain.model.Room
+import dev.nonoxy.residetrack.core.rooms.domain.model.Student
+import dev.nonoxy.residetrack.core.rooms.domain.upcoming.UpcomingBucket
 import kotlinx.datetime.LocalDate
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/shared/feature-upcoming/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/upcoming/presentation/models/UiUpcomingItem.kt
+++ b/shared/feature-upcoming/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/upcoming/presentation/models/UiUpcomingItem.kt
@@ -1,6 +1,6 @@
 package dev.nonoxy.residetrack.feature.upcoming.presentation.models
 
-import dev.nonoxy.residetrack.core.rooms.upcoming.UpcomingBucket
+import dev.nonoxy.residetrack.core.rooms.domain.upcoming.UpcomingBucket
 
 data class UiUpcomingItem(
     val roomId: Long,

--- a/shared/feature-upcoming/presentation/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/upcoming/presentation/mappers/UiUpcomingStateMapperTest.kt
+++ b/shared/feature-upcoming/presentation/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/upcoming/presentation/mappers/UiUpcomingStateMapperTest.kt
@@ -1,6 +1,6 @@
 package dev.nonoxy.residetrack.feature.upcoming.presentation.mappers
 
-import dev.nonoxy.residetrack.core.rooms.upcoming.UpcomingBucket
+import dev.nonoxy.residetrack.core.rooms.domain.upcoming.UpcomingBucket
 import dev.nonoxy.residetrack.feature.upcoming.api.models.UpcomingItem
 import dev.nonoxy.residetrack.feature.upcoming.api.store.UpcomingStore
 import kotlinx.datetime.LocalDate

--- a/shared/feature-upcoming/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/upcoming/ui/views/UpcomingList.kt
+++ b/shared/feature-upcoming/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/upcoming/ui/views/UpcomingList.kt
@@ -18,7 +18,7 @@ import dev.nonoxy.residetrack.common.ui.theme.padding_size_4
 import dev.nonoxy.residetrack.common.ui.theme.padding_size_8
 import dev.nonoxy.residetrack.common.ui.theme.padding_size_20
 import dev.nonoxy.residetrack.core.navigation.bottombar.LocalFloatingBottomBarInset
-import dev.nonoxy.residetrack.core.rooms.upcoming.UpcomingBucket
+import dev.nonoxy.residetrack.core.rooms.domain.upcoming.UpcomingBucket
 import dev.nonoxy.residetrack.feature.upcoming.presentation.models.UiUpcomingItem
 import dev.nonoxy.residetrack.res.MR
 import kotlinx.collections.immutable.ImmutableList

--- a/shared/feature-upcoming/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/upcoming/ui/views/UpcomingListItem.kt
+++ b/shared/feature-upcoming/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/upcoming/ui/views/UpcomingListItem.kt
@@ -22,7 +22,7 @@ import dev.nonoxy.residetrack.common.ui.theme.padding_size_10
 import dev.nonoxy.residetrack.common.ui.theme.padding_size_12
 import dev.nonoxy.residetrack.common.ui.theme.padding_size_2
 import dev.nonoxy.residetrack.common.ui.theme.padding_size_4
-import dev.nonoxy.residetrack.core.rooms.upcoming.UpcomingBucket
+import dev.nonoxy.residetrack.core.rooms.domain.upcoming.UpcomingBucket
 import dev.nonoxy.residetrack.feature.upcoming.presentation.models.UiUpcomingItem
 import dev.nonoxy.residetrack.res.MR
 import org.jetbrains.compose.ui.tooling.preview.Preview

--- a/shared/feature-upcoming/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/upcoming/ui/views/UpcomingScreenDetails.kt
+++ b/shared/feature-upcoming/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/upcoming/ui/views/UpcomingScreenDetails.kt
@@ -5,7 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import dev.nonoxy.residetrack.common.ui.common.state.ShowStateData
 import dev.nonoxy.residetrack.common.ui.theme.ResideTrackTheme
-import dev.nonoxy.residetrack.core.rooms.upcoming.UpcomingBucket
+import dev.nonoxy.residetrack.core.rooms.domain.upcoming.UpcomingBucket
 import dev.nonoxy.residetrack.feature.upcoming.presentation.models.UiUpcomingItem
 import dev.nonoxy.residetrack.feature.upcoming.presentation.models.UiUpcomingState
 import kotlinx.collections.immutable.persistentListOf

--- a/shared/main/src/commonMain/kotlin/dev/nonoxy/residetrack/di/Koin.kt
+++ b/shared/main/src/commonMain/kotlin/dev/nonoxy/residetrack/di/Koin.kt
@@ -4,6 +4,7 @@ import dev.nonoxy.residetrack.common.di.commonModule
 import dev.nonoxy.residetrack.core.database.di.coreDatabaseModule
 import dev.nonoxy.residetrack.core.initializer.di.coreInitializerModule
 import dev.nonoxy.residetrack.core.rooms.di.coreRoomsModule
+import dev.nonoxy.residetrack.core.backup.di.coreBackupModule
 import dev.nonoxy.residetrack.feature.splash.presentation.di.featureSplashPresentationModule
 import dev.nonoxy.residetrack.feature.add_room.impl.di.featureAddRoomImplModule
 import dev.nonoxy.residetrack.feature.add_room.presentation.di.featureAddRoomPresentationModule
@@ -36,6 +37,7 @@ fun initKoin(appDeclaration: KoinAppDeclaration? = null) {
             coreDatabaseModule,
             coreInitializerModule,
             coreRoomsModule,
+            coreBackupModule,
 
             featureSplashPresentationModule,
 

--- a/shared/main/src/commonMain/kotlin/dev/nonoxy/residetrack/ui/tabcontainer/TabContainerViewModel.kt
+++ b/shared/main/src/commonMain/kotlin/dev/nonoxy/residetrack/ui/tabcontainer/TabContainerViewModel.kt
@@ -3,8 +3,8 @@ package dev.nonoxy.residetrack.ui.tabcontainer
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dev.nonoxy.residetrack.common.utils.currentLocalDate
-import dev.nonoxy.residetrack.core.rooms.repository.RoomsRepository
-import dev.nonoxy.residetrack.core.rooms.upcoming.UpcomingCheckouts
+import dev.nonoxy.residetrack.core.rooms.domain.repository.RoomsRepository
+import dev.nonoxy.residetrack.core.rooms.domain.upcoming.UpcomingCheckouts
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch


### PR DESCRIPTION
Резервная копия базы на случай аварии: экспорт всех комнат и жильцов в JSON-файл и восстановление из него. Восстановление деструктивное — полностью заменяет текущие данные (replace-all), без слияния/облака/шифрования (YAGNI).

## Что внутри
- **`core-database`**: `replaceAllRoomsWithStudents` — атомарный wipe+fill в одной транзакции, id регенерируются.
- **`core-backup`** (новый модуль): `BackupRepository` (export/parse/restore), DTO заперт в data-слое, наружу торчат только доменные типы и `kotlin.Result`. Зависит только от `core-database` (без горизонтальных зависимостей на `core-rooms`).
- **`feature-rooms`**: ⋮-меню в топбаре, двухфазный импорт (parse → подтверждение со счётчиком → restore), системные пикеры (SAF на Android, `UIDocumentPickerViewController` на iOS).
- **Рефактор `core-rooms`**: модели/репозиторий/валидация сгруппированы под `domain/`.

## Безопасность данных и edge-cases
- Экспорт пустой БД и импорт пустой копии — заблокированы (не пишем мусорный файл, не стираем всё ради 0 комнат).
- Диалог подтверждения показывает **что будет удалено** («Сейчас: N комнат» красным) рядом с тем, что придёт.
- Несовместимая версия копии и битый файл разнесены на разные сообщения.
- Пикеры: гард на `ActivityNotFoundException`, файловый IO уведён с main-потока, на iOS — проверка `fileExistsAtPath` перед рапортом успеха, освобождение security-scoped ресурса в finally, чистка temp-файла, `rememberSaveable` против process-death на Android.
- JSON-сериализация на `Dispatchers.Default`.

## Тесты
`core-backup` (round-trip, версия, счётчики, битый файл), `feature-rooms` executor (export/import/restore, пустые, версия, ошибка restore), presentation state-mapper. Полный `iosSimulatorArm64Test` зелёный, Android APK (dev+prod) собирается.

## Вне этого PR (отдельный рефактор)
Вынос `RoomsSeedInitializer` из `domain/` и расщепление висячих enum'ов в `AddRoomStore`/`RoomEditorStore`.