### PR TITLE
refactor: вынос seed из domain + расщепление висячих kind-типов

### DIFF
--- a/shared/feature-add-room/api/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/add_room/api/store/AddRoomErrorKind.kt
+++ b/shared/feature-add-room/api/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/add_room/api/store/AddRoomErrorKind.kt
@@ -1,0 +1,10 @@
+package dev.nonoxy.residetrack.feature.add_room.api.store
+
+sealed interface AddRoomErrorKind {
+    data object UnknownError : AddRoomErrorKind
+    data object SaveFailed : AddRoomErrorKind
+    data class RoomAlreadyExists(val roomNumber: Int, val floorNumber: Int) : AddRoomErrorKind
+    data object FloorNumberRequired : AddRoomErrorKind
+    data object RoomNumberRequired : AddRoomErrorKind
+    data object BedsCountRequired : AddRoomErrorKind
+}

--- a/shared/feature-add-room/api/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/add_room/api/store/AddRoomStore.kt
+++ b/shared/feature-add-room/api/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/add_room/api/store/AddRoomStore.kt
@@ -66,16 +66,3 @@ interface AddRoomStore : Store<Intent, State, Label> {
         data class ShowError(val kind: AddRoomErrorKind) : Label
     }
 }
-
-sealed interface AddRoomErrorKind {
-    data object UnknownError : AddRoomErrorKind
-    data object SaveFailed : AddRoomErrorKind
-    data class RoomAlreadyExists(val roomNumber: Int, val floorNumber: Int) : AddRoomErrorKind
-    data object FloorNumberRequired : AddRoomErrorKind
-    data object RoomNumberRequired : AddRoomErrorKind
-    data object BedsCountRequired : AddRoomErrorKind
-}
-
-sealed interface AddRoomSuccessKind {
-    data class RoomCreated(val roomNumber: Int) : AddRoomSuccessKind
-}

--- a/shared/feature-add-room/api/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/add_room/api/store/AddRoomSuccessKind.kt
+++ b/shared/feature-add-room/api/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/add_room/api/store/AddRoomSuccessKind.kt
@@ -1,0 +1,5 @@
+package dev.nonoxy.residetrack.feature.add_room.api.store
+
+sealed interface AddRoomSuccessKind {
+    data class RoomCreated(val roomNumber: Int) : AddRoomSuccessKind
+}

--- a/shared/feature-room-editor/api/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/api/store/RoomEditorErrorKind.kt
+++ b/shared/feature-room-editor/api/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/api/store/RoomEditorErrorKind.kt
@@ -1,0 +1,15 @@
+package dev.nonoxy.residetrack.feature.room_editor.api.store
+
+sealed interface RoomEditorErrorKind {
+    data object FailedToLoadStudents : RoomEditorErrorKind
+    data object FailedToSaveStudents : RoomEditorErrorKind
+    data object RoomNotFound : RoomEditorErrorKind
+    data object DraftRoomNotFound : RoomEditorErrorKind
+    data object StreamNumberInvalid : RoomEditorErrorKind
+    data object InvalidDateRange : RoomEditorErrorKind
+    data object InvalidDateFormat : RoomEditorErrorKind
+    data object DuplicateStreamNumbers : RoomEditorErrorKind
+    data object RoomNumberTaken : RoomEditorErrorKind
+    data object FailedToUpdateRoom : RoomEditorErrorKind
+    data object FailedToDeleteRoom : RoomEditorErrorKind
+}

--- a/shared/feature-room-editor/api/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/api/store/RoomEditorStore.kt
+++ b/shared/feature-room-editor/api/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/api/store/RoomEditorStore.kt
@@ -84,23 +84,3 @@ interface RoomEditorStore : Store<Intent, State, Label> {
         data class ShowSuccess(val kind: RoomEditorSuccessKind) : Label
     }
 }
-
-sealed interface RoomEditorErrorKind {
-    data object FailedToLoadStudents : RoomEditorErrorKind
-    data object FailedToSaveStudents : RoomEditorErrorKind
-    data object RoomNotFound : RoomEditorErrorKind
-    data object DraftRoomNotFound : RoomEditorErrorKind
-    data object StreamNumberInvalid : RoomEditorErrorKind
-    data object InvalidDateRange : RoomEditorErrorKind
-    data object InvalidDateFormat : RoomEditorErrorKind
-    data object DuplicateStreamNumbers : RoomEditorErrorKind
-    data object RoomNumberTaken : RoomEditorErrorKind
-    data object FailedToUpdateRoom : RoomEditorErrorKind
-    data object FailedToDeleteRoom : RoomEditorErrorKind
-}
-
-sealed interface RoomEditorSuccessKind {
-    data object StudentsSaved : RoomEditorSuccessKind
-    data object RoomUpdated : RoomEditorSuccessKind
-    data object RoomDeleted : RoomEditorSuccessKind
-}

--- a/shared/feature-room-editor/api/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/api/store/RoomEditorSuccessKind.kt
+++ b/shared/feature-room-editor/api/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/api/store/RoomEditorSuccessKind.kt
@@ -1,0 +1,7 @@
+package dev.nonoxy.residetrack.feature.room_editor.api.store
+
+sealed interface RoomEditorSuccessKind {
+    data object StudentsSaved : RoomEditorSuccessKind
+    data object RoomUpdated : RoomEditorSuccessKind
+    data object RoomDeleted : RoomEditorSuccessKind
+}

--- a/shared/feature-rooms/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/di/FeatureRoomsImplModule.kt
+++ b/shared/feature-rooms/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/di/FeatureRoomsImplModule.kt
@@ -3,7 +3,7 @@ package dev.nonoxy.residetrack.feature.rooms.impl.di
 import dev.nonoxy.residetrack.common.coroutines.CoroutineDispatchers
 import dev.nonoxy.residetrack.feature.rooms.api.store.RoomsStore
 import dev.nonoxy.residetrack.feature.rooms.impl.domain.RoomsStoreFactory
-import dev.nonoxy.residetrack.feature.rooms.impl.domain.seed.RoomsSeedInitializer
+import dev.nonoxy.residetrack.feature.rooms.impl.seed.RoomsSeedInitializer
 import dev.nonoxy.residetrack.core.initializer.Initializer
 import org.koin.core.module.dsl.factoryOf
 import org.koin.dsl.bind

--- a/shared/feature-rooms/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/seed/RoomSeed.kt
+++ b/shared/feature-rooms/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/seed/RoomSeed.kt
@@ -1,4 +1,4 @@
-package dev.nonoxy.residetrack.feature.rooms.impl.domain.seed
+package dev.nonoxy.residetrack.feature.rooms.impl.seed
 
 import kotlinx.serialization.Serializable
 

--- a/shared/feature-rooms/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/seed/RoomsSeedInitializer.kt
+++ b/shared/feature-rooms/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/seed/RoomsSeedInitializer.kt
@@ -1,4 +1,4 @@
-package dev.nonoxy.residetrack.feature.rooms.impl.domain.seed
+package dev.nonoxy.residetrack.feature.rooms.impl.seed
 
 import dev.nonoxy.residetrack.common.resources.FileResourceReader
 import dev.nonoxy.residetrack.core.database.dao.RoomDao


### PR DESCRIPTION
Чистка структуры (carry-over из room-editor), без изменения поведения.

## 1. Seed вне domain
`RoomsSeedInitializer` и `RoomSeed` сидят предзаполненную структуру комнат при первом запуске — это инфраструктура инициализации, не доменная логика. Пакет `feature.rooms.impl.domain.seed` → `feature.rooms.impl.seed`, поправлен импорт в DI-модуле.

## 2. Single-type-per-file для store-контрактов
`AddRoomStore` и `RoomEditorStore` держали `*ErrorKind` / `*SuccessKind` sealed-интерфейсы на уровне файла рядом с контрактом стора. Каждый тип вынесен в свой файл в том же пакете — импорты потребителей не меняются:
- `AddRoomErrorKind`, `AddRoomSuccessKind`
- `RoomEditorErrorKind`, `RoomEditorSuccessKind`

`DateField` оставлен вложенным в `RoomEditorStore` — он часть MVI-контракта (как `State`/`Intent`/`Label`), не висячий.

Проверено: compile всех затронутых модулей (api/impl/presentation/ui) + allTests feature-add-room и feature-room-editor — зелёные.