### PR TITLE
fix(backup): импорт не открывал пикер из-за рекурсии в Android-пикере

### DIFF
--- a/shared/feature-rooms/ui/src/androidMain/kotlin/dev/nonoxy/residetrack/feature/rooms/ui/BackupFilePicker.android.kt
+++ b/shared/feature-rooms/ui/src/androidMain/kotlin/dev/nonoxy/residetrack/feature/rooms/ui/BackupFilePicker.android.kt
@@ -64,7 +64,7 @@ internal actual fun rememberBackupFilePicker(
                 pendingJson = json
                 createLauncher.launch(name)
             },
-            launchOpen = { openLauncher.launch(arrayOf("application/json")) },
+            launchOpenPicker = { openLauncher.launch(arrayOf("application/json")) },
             onExportCompleted = onExportCompleted,
             clearPending = { pendingJson = null },
         )
@@ -73,7 +73,7 @@ internal actual fun rememberBackupFilePicker(
 
 private class AndroidBackupFilePicker(
     private val launchCreate: (name: String, json: String) -> Unit,
-    private val launchOpen: () -> Unit,
+    private val launchOpenPicker: () -> Unit,
     private val onExportCompleted: (Boolean) -> Unit,
     private val clearPending: () -> Unit,
 ) : BackupFilePicker {
@@ -90,6 +90,6 @@ private class AndroidBackupFilePicker(
 
     override fun launchOpen() {
         // No completion signal on the open path — a missing provider just means no picker appears.
-        runCatching { launchOpen() }
+        runCatching { launchOpenPicker() }
     }
 }


### PR DESCRIPTION
## Проблема
На Android тап «Восстановить из копии» не открывал системный выбор файла — «ничего не происходит». Экспорт при этом работал.

## Причина
В `AndroidBackupFilePicker` имя конструкторного свойства `launchOpen` совпадало с override-методом `launchOpen()`. Внутри метода вызов `launchOpen()` резолвился в саму член-функцию (приоритет над `invoke` свойства), а не в лямбду → бесконечная рекурсия → `StackOverflowError`, который глушился `runCatching`. Пикер не стартовал.

Экспорт работал, т.к. там имена свойства (`launchCreate`) и метода (`launchSave`) различались.

## Фикс
Свойство `launchOpen` переименовано в `launchOpenPicker` — коллизия имён убрана.

## Проверка
Воспроизведено и подтверждено на эмуляторе (Android 16): до фикса `OnImportClick` доходил до Store, но `PickActivity` не стартовал; инструментирование поймало `StackOverflowError`; после фикса import открывает DocumentsUI.