### PR TITLE
feat(navigation): увеличить текст в табах

### DIFF
--- a/shared/core-navigation/src/commonMain/kotlin/dev/nonoxy/residetrack/core/navigation/bottombar/FloatingBottomBar.kt
+++ b/shared/core-navigation/src/commonMain/kotlin/dev/nonoxy/residetrack/core/navigation/bottombar/FloatingBottomBar.kt
@@ -100,7 +100,7 @@ private fun BottomBarTab(
         }
         Text(
             text = item.label,
-            style = ResideTrackTheme.typography.head5,
+            style = ResideTrackTheme.typography.head4,
             color = contentColor,
         )
     }


### PR DESCRIPTION
Размер лейбла таба бампнут с head5 (12sp) до head4 (14sp) — крупнее и читабельнее. Токен дизайн-системы, без хардкода размеров.