### PR TITLE
refactor(upcoming): bucket titles/colors via presentation model

### DIFF
--- a/shared/feature-upcoming/presentation/build.gradle.kts
+++ b/shared/feature-upcoming/presentation/build.gradle.kts
@@ -13,6 +13,7 @@ androidLibraryConfig {
 
 commonMainDependencies {
     implementations(
+        projects.shared.commonResources,
         libs.kotlin.immutableCollections,
         libs.kotlin.datetime,
     )

--- a/shared/feature-upcoming/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/upcoming/presentation/mappers/UiUpcomingStateMapper.kt
+++ b/shared/feature-upcoming/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/upcoming/presentation/mappers/UiUpcomingStateMapper.kt
@@ -1,6 +1,8 @@
 package dev.nonoxy.residetrack.feature.upcoming.presentation.mappers
 
+import dev.nonoxy.residetrack.core.rooms.domain.upcoming.UpcomingBucket
 import dev.nonoxy.residetrack.feature.upcoming.api.store.UpcomingStore
+import dev.nonoxy.residetrack.feature.upcoming.presentation.models.UiUpcomingBucket
 import dev.nonoxy.residetrack.feature.upcoming.presentation.models.UiUpcomingItem
 import dev.nonoxy.residetrack.feature.upcoming.presentation.models.UiUpcomingState
 import kotlinx.collections.immutable.toImmutableList
@@ -22,8 +24,14 @@ internal class UiUpcomingStateMapperImpl : UiUpcomingStateMapper {
                 streamNumber = domain.streamNumber.toString(),
                 checkOutDate = domain.checkOutDate.toString(),
                 daysLeft = domain.daysLeft,
-                bucket = domain.bucket,
+                bucket = domain.bucket.toUi(),
             )
         }.toImmutableList(),
     )
+
+    private fun UpcomingBucket.toUi(): UiUpcomingBucket = when (this) {
+        UpcomingBucket.OVERDUE -> UiUpcomingBucket.OVERDUE
+        UpcomingBucket.TODAY_TOMORROW -> UiUpcomingBucket.TODAY_TOMORROW
+        UpcomingBucket.THIS_WEEK -> UiUpcomingBucket.THIS_WEEK
+    }
 }

--- a/shared/feature-upcoming/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/upcoming/presentation/models/UiUpcomingBucket.kt
+++ b/shared/feature-upcoming/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/upcoming/presentation/models/UiUpcomingBucket.kt
@@ -1,0 +1,19 @@
+package dev.nonoxy.residetrack.feature.upcoming.presentation.models
+
+import dev.icerock.moko.resources.StringResource
+import dev.nonoxy.residetrack.res.MR
+
+enum class UiUpcomingBucket {
+    OVERDUE,
+    TODAY_TOMORROW,
+    THIS_WEEK;
+
+    // Computed, not a constructor arg: keeps enum init free of moko-resources so
+    // pure mapping logic (and its native unit tests) never trigger MR class init.
+    val title: StringResource
+        get() = when (this) {
+            OVERDUE -> MR.strings.upcoming_bucket_overdue
+            TODAY_TOMORROW -> MR.strings.upcoming_bucket_today_tomorrow
+            THIS_WEEK -> MR.strings.upcoming_bucket_this_week
+        }
+}

--- a/shared/feature-upcoming/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/upcoming/presentation/models/UiUpcomingItem.kt
+++ b/shared/feature-upcoming/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/upcoming/presentation/models/UiUpcomingItem.kt
@@ -1,7 +1,5 @@
 package dev.nonoxy.residetrack.feature.upcoming.presentation.models
 
-import dev.nonoxy.residetrack.core.rooms.domain.upcoming.UpcomingBucket
-
 data class UiUpcomingItem(
     val roomId: Long,
     val roomNumber: String,
@@ -9,5 +7,5 @@ data class UiUpcomingItem(
     val streamNumber: String,
     val checkOutDate: String, // ISO-8601
     val daysLeft: Int,
-    val bucket: UpcomingBucket,
+    val bucket: UiUpcomingBucket,
 )

--- a/shared/feature-upcoming/presentation/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/upcoming/presentation/mappers/UiUpcomingStateMapperTest.kt
+++ b/shared/feature-upcoming/presentation/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/upcoming/presentation/mappers/UiUpcomingStateMapperTest.kt
@@ -3,6 +3,7 @@ package dev.nonoxy.residetrack.feature.upcoming.presentation.mappers
 import dev.nonoxy.residetrack.core.rooms.domain.upcoming.UpcomingBucket
 import dev.nonoxy.residetrack.feature.upcoming.api.models.UpcomingItem
 import dev.nonoxy.residetrack.feature.upcoming.api.store.UpcomingStore
+import dev.nonoxy.residetrack.feature.upcoming.presentation.models.UiUpcomingBucket
 import kotlinx.datetime.LocalDate
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -39,6 +40,6 @@ class UiUpcomingStateMapperTest {
         assertEquals("305", item.streamNumber)
         assertEquals("2026-06-01", item.checkOutDate)
         assertEquals(-3, item.daysLeft)
-        assertEquals(UpcomingBucket.OVERDUE, item.bucket)
+        assertEquals(UiUpcomingBucket.OVERDUE, item.bucket)
     }
 }

--- a/shared/feature-upcoming/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/upcoming/ui/views/UpcomingList.kt
+++ b/shared/feature-upcoming/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/upcoming/ui/views/UpcomingList.kt
@@ -18,9 +18,8 @@ import dev.nonoxy.residetrack.common.ui.theme.padding_size_4
 import dev.nonoxy.residetrack.common.ui.theme.padding_size_8
 import dev.nonoxy.residetrack.common.ui.theme.padding_size_20
 import dev.nonoxy.residetrack.core.navigation.bottombar.LocalFloatingBottomBarInset
-import dev.nonoxy.residetrack.core.rooms.domain.upcoming.UpcomingBucket
+import dev.nonoxy.residetrack.feature.upcoming.presentation.models.UiUpcomingBucket
 import dev.nonoxy.residetrack.feature.upcoming.presentation.models.UiUpcomingItem
-import dev.nonoxy.residetrack.res.MR
 import kotlinx.collections.immutable.ImmutableList
 
 @Composable
@@ -39,7 +38,7 @@ internal fun UpcomingList(
         ),
         verticalArrangement = Arrangement.spacedBy(padding_size_8),
     ) {
-        for (bucket in UpcomingBucket.entries) {
+        for (bucket in UiUpcomingBucket.entries) {
             val bucketItems = items.filter { it.bucket == bucket }
             if (bucketItems.isEmpty()) continue
 
@@ -64,17 +63,12 @@ internal fun UpcomingList(
 }
 
 @Composable
-private fun BucketHeader(bucket: UpcomingBucket) {
-    val title = when (bucket) {
-        UpcomingBucket.OVERDUE -> MR.strings.upcoming_bucket_overdue
-        UpcomingBucket.TODAY_TOMORROW -> MR.strings.upcoming_bucket_today_tomorrow
-        UpcomingBucket.THIS_WEEK -> MR.strings.upcoming_bucket_this_week
-    }
+private fun BucketHeader(bucket: UiUpcomingBucket) {
     Text(
         modifier = Modifier
             .fillMaxWidth()
             .padding(top = padding_size_20, bottom = padding_size_4),
-        text = stringResource(title),
+        text = stringResource(bucket.title),
         style = ResideTrackTheme.typography.head5,
         color = ResideTrackTheme.colors.textCaption,
     )

--- a/shared/feature-upcoming/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/upcoming/ui/views/UpcomingListItem.kt
+++ b/shared/feature-upcoming/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/upcoming/ui/views/UpcomingListItem.kt
@@ -22,7 +22,7 @@ import dev.nonoxy.residetrack.common.ui.theme.padding_size_10
 import dev.nonoxy.residetrack.common.ui.theme.padding_size_12
 import dev.nonoxy.residetrack.common.ui.theme.padding_size_2
 import dev.nonoxy.residetrack.common.ui.theme.padding_size_4
-import dev.nonoxy.residetrack.core.rooms.domain.upcoming.UpcomingBucket
+import dev.nonoxy.residetrack.feature.upcoming.presentation.models.UiUpcomingBucket
 import dev.nonoxy.residetrack.feature.upcoming.presentation.models.UiUpcomingItem
 import dev.nonoxy.residetrack.res.MR
 import org.jetbrains.compose.ui.tooling.preview.Preview
@@ -72,7 +72,7 @@ internal fun UpcomingListItem(
 @Composable
 private fun DaysLeftBadge(
     daysLeft: Int,
-    bucket: UpcomingBucket,
+    bucket: UiUpcomingBucket,
     modifier: Modifier = Modifier,
 ) {
     val text = if (daysLeft < 0) {
@@ -81,14 +81,14 @@ private fun DaysLeftBadge(
         stringResource(MR.strings.upcoming_days_left, daysLeft.toString())
     }
     val backgroundColor = when (bucket) {
-        UpcomingBucket.OVERDUE -> ResideTrackTheme.colors.fillErrorBGSecondary
-        UpcomingBucket.TODAY_TOMORROW -> ResideTrackTheme.colors.fillWarningBGSecondary
-        UpcomingBucket.THIS_WEEK -> ResideTrackTheme.colors.fillSuccessBGSecondary
+        UiUpcomingBucket.OVERDUE -> ResideTrackTheme.colors.fillErrorBGSecondary
+        UiUpcomingBucket.TODAY_TOMORROW -> ResideTrackTheme.colors.fillWarningBGSecondary
+        UiUpcomingBucket.THIS_WEEK -> ResideTrackTheme.colors.fillSuccessBGSecondary
     }
     val textColor = when (bucket) {
-        UpcomingBucket.OVERDUE -> ResideTrackTheme.colors.textError
-        UpcomingBucket.TODAY_TOMORROW -> ResideTrackTheme.colors.textWarning
-        UpcomingBucket.THIS_WEEK -> ResideTrackTheme.colors.textSuccess
+        UiUpcomingBucket.OVERDUE -> ResideTrackTheme.colors.textError
+        UiUpcomingBucket.TODAY_TOMORROW -> ResideTrackTheme.colors.textWarning
+        UiUpcomingBucket.THIS_WEEK -> ResideTrackTheme.colors.textSuccess
     }
     Text(
         modifier = modifier
@@ -120,7 +120,7 @@ private fun Preview() {
                     streamNumber = "1234",
                     checkOutDate = "2024-03-31",
                     daysLeft = -2,
-                    bucket = UpcomingBucket.OVERDUE,
+                    bucket = UiUpcomingBucket.OVERDUE,
                 ),
                 onClick = {}
             )
@@ -133,7 +133,7 @@ private fun Preview() {
                     streamNumber = "5646",
                     checkOutDate = "2024-04-02",
                     daysLeft = 1,
-                    bucket = UpcomingBucket.TODAY_TOMORROW,
+                    bucket = UiUpcomingBucket.TODAY_TOMORROW,
                 ),
                 onClick = {}
             )
@@ -146,7 +146,7 @@ private fun Preview() {
                     streamNumber = "7777",
                     checkOutDate = "2024-04-06",
                     daysLeft = 5,
-                    bucket = UpcomingBucket.THIS_WEEK,
+                    bucket = UiUpcomingBucket.THIS_WEEK,
                 ),
                 onClick = {}
             )

--- a/shared/feature-upcoming/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/upcoming/ui/views/UpcomingScreenDetails.kt
+++ b/shared/feature-upcoming/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/upcoming/ui/views/UpcomingScreenDetails.kt
@@ -5,7 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import dev.nonoxy.residetrack.common.ui.common.state.ShowStateData
 import dev.nonoxy.residetrack.common.ui.theme.ResideTrackTheme
-import dev.nonoxy.residetrack.core.rooms.domain.upcoming.UpcomingBucket
+import dev.nonoxy.residetrack.feature.upcoming.presentation.models.UiUpcomingBucket
 import dev.nonoxy.residetrack.feature.upcoming.presentation.models.UiUpcomingItem
 import dev.nonoxy.residetrack.feature.upcoming.presentation.models.UiUpcomingState
 import kotlinx.collections.immutable.persistentListOf
@@ -52,7 +52,7 @@ private fun Preview() {
                         streamNumber = "1234",
                         checkOutDate = "2024-03-31",
                         daysLeft = -2,
-                        bucket = UpcomingBucket.OVERDUE,
+                        bucket = UiUpcomingBucket.OVERDUE,
                     ),
                     UiUpcomingItem(
                         roomId = 2,
@@ -61,7 +61,7 @@ private fun Preview() {
                         streamNumber = "5646",
                         checkOutDate = "2024-04-02",
                         daysLeft = 1,
-                        bucket = UpcomingBucket.TODAY_TOMORROW,
+                        bucket = UiUpcomingBucket.TODAY_TOMORROW,
                     ),
                 )
             ),


### PR DESCRIPTION
Introduce `UiUpcomingBucket` (title as StringResource); the UI reads it instead of mapping the domain `UpcomingBucket` to MR.strings inside @Composable. Adds the missing common-resources dependency to the presentation module.