### PR TITLE
refactor(core-rooms): drop dead methods + extract DraftRoomRepository

### DIFF
--- a/shared/core-rooms/src/commonMain/kotlin/dev/nonoxy/residetrack/core/rooms/data/DraftRoomRepositoryImpl.kt
+++ b/shared/core-rooms/src/commonMain/kotlin/dev/nonoxy/residetrack/core/rooms/data/DraftRoomRepositoryImpl.kt
@@ -1,0 +1,47 @@
+package dev.nonoxy.residetrack.core.rooms.data
+
+import dev.nonoxy.residetrack.common.coroutines.CoroutineDispatchers
+import dev.nonoxy.residetrack.common.utils.coRunCatching
+import dev.nonoxy.residetrack.common.utils.wrapFailure
+import dev.nonoxy.residetrack.common.utils.wrapSuccess
+import dev.nonoxy.residetrack.core.rooms.data.storage.DraftRoomStorage
+import dev.nonoxy.residetrack.core.rooms.domain.model.Room
+import dev.nonoxy.residetrack.core.rooms.domain.repository.DraftRoomRepository
+import io.github.aakira.napier.Napier
+import kotlinx.coroutines.withContext
+
+internal class DraftRoomRepositoryImpl(
+    private val storage: DraftRoomStorage,
+    private val dispatchers: CoroutineDispatchers,
+) : DraftRoomRepository {
+
+    override suspend fun save(room: Room): Result<Unit> = withContext(dispatchers.io) {
+        coRunCatching(
+            tryBlock = { storage.save(room).wrapSuccess() },
+            catchBlock = { throwable ->
+                Napier.e(throwable) { "Error occur on saving draft room: $room" }
+                throwable.wrapFailure()
+            }
+        )
+    }
+
+    override suspend fun get(): Result<Room?> = withContext(dispatchers.io) {
+        coRunCatching(
+            tryBlock = { storage.get().wrapSuccess() },
+            catchBlock = { throwable ->
+                Napier.e(throwable) { "Error occur on getting draft room" }
+                throwable.wrapFailure()
+            }
+        )
+    }
+
+    override suspend fun clear(): Result<Unit> = withContext(dispatchers.io) {
+        coRunCatching(
+            tryBlock = { storage.clear().wrapSuccess() },
+            catchBlock = { throwable ->
+                Napier.e(throwable) { "Error occur on clearing draft room" }
+                throwable.wrapFailure()
+            }
+        )
+    }
+}

--- a/shared/core-rooms/src/commonMain/kotlin/dev/nonoxy/residetrack/core/rooms/data/RoomsRepositoryImpl.kt
+++ b/shared/core-rooms/src/commonMain/kotlin/dev/nonoxy/residetrack/core/rooms/data/RoomsRepositoryImpl.kt
@@ -13,7 +13,6 @@ import dev.nonoxy.residetrack.core.rooms.domain.model.Room
 import dev.nonoxy.residetrack.core.rooms.domain.repository.RoomsRepository
 import io.github.aakira.napier.Napier
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
@@ -24,8 +23,6 @@ internal class RoomsRepositoryImpl(
     private val studentMapper: StudentMapper,
     private val dispatchers: CoroutineDispatchers,
 ) : RoomsRepository {
-
-    private val _draftRoom = MutableStateFlow<Room?>(null)
 
     override fun observeRooms(): Flow<List<Room>> =
         roomStorage.observeAllRoomsWithStudents()
@@ -111,42 +108,6 @@ internal class RoomsRepositoryImpl(
             },
             catchBlock = { throwable ->
                 Napier.e(throwable) { "Error deleting room: $roomId" }
-                throwable.wrapFailure()
-            }
-        )
-    }
-
-    override suspend fun saveDraftRoom(room: Room): Result<Unit> = withContext(dispatchers.io) {
-        coRunCatching(
-            tryBlock = {
-                _draftRoom.value = room
-                Unit.wrapSuccess()
-            },
-            catchBlock = { throwable ->
-                Napier.e(throwable) { "Error occur on saving draft room: $room" }
-                throwable.wrapFailure()
-            }
-        )
-    }
-
-    override suspend fun getDraftRoom(): Result<Room?> = withContext(dispatchers.io) {
-        coRunCatching(
-            tryBlock = { _draftRoom.value.wrapSuccess() },
-            catchBlock = { throwable ->
-                Napier.e(throwable) { "Error occur on getting draft room" }
-                throwable.wrapFailure()
-            }
-        )
-    }
-
-    override suspend fun clearDraftRoom(): Result<Unit> = withContext(dispatchers.io) {
-        coRunCatching(
-            tryBlock = {
-                _draftRoom.value = null
-                Unit.wrapSuccess()
-            },
-            catchBlock = { throwable ->
-                Napier.e(throwable) { "Error occur on clearing draft room" }
                 throwable.wrapFailure()
             }
         )

--- a/shared/core-rooms/src/commonMain/kotlin/dev/nonoxy/residetrack/core/rooms/data/RoomsRepositoryImpl.kt
+++ b/shared/core-rooms/src/commonMain/kotlin/dev/nonoxy/residetrack/core/rooms/data/RoomsRepositoryImpl.kt
@@ -14,7 +14,6 @@ import dev.nonoxy.residetrack.core.rooms.domain.repository.RoomsRepository
 import io.github.aakira.napier.Napier
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
@@ -42,22 +41,6 @@ internal class RoomsRepositoryImpl(
             },
             catchBlock = { throwable ->
                 Napier.e(throwable) { "Error occur on getting all rooms" }
-                throwable.wrapFailure()
-            }
-        )
-    }
-
-    override suspend fun getRoomByNumber(
-        roomNumber: Int
-    ): Result<Room?> = withContext(dispatchers.io) {
-        coRunCatching(
-            tryBlock = {
-                roomStorage.getRoomWithStudentsByRoomNumber(roomNumber = roomNumber)
-                    ?.mapToDomain()
-                    .wrapSuccess()
-            },
-            catchBlock = { throwable ->
-                Napier.e(throwable) { "Error occur on getting room by number: $roomNumber" }
                 throwable.wrapFailure()
             }
         )
@@ -168,8 +151,6 @@ internal class RoomsRepositoryImpl(
             }
         )
     }
-
-    override fun observeDraftRoom(): Flow<Room?> = _draftRoom.asStateFlow()
 
     private fun RoomWithStudents.mapToDomain(): Room = roomMapper.map(this)
     private fun List<RoomWithStudents>.mapToDomain(): List<Room> = map { it.mapToDomain() }

--- a/shared/core-rooms/src/commonMain/kotlin/dev/nonoxy/residetrack/core/rooms/data/storage/DraftRoomStorage.kt
+++ b/shared/core-rooms/src/commonMain/kotlin/dev/nonoxy/residetrack/core/rooms/data/storage/DraftRoomStorage.kt
@@ -1,0 +1,13 @@
+package dev.nonoxy.residetrack.core.rooms.data.storage
+
+import dev.nonoxy.residetrack.core.rooms.domain.model.Room
+
+/** Store for the single room being drafted while add-room hands off to the editor. */
+internal interface DraftRoomStorage {
+
+    fun save(room: Room)
+
+    fun get(): Room?
+
+    fun clear()
+}

--- a/shared/core-rooms/src/commonMain/kotlin/dev/nonoxy/residetrack/core/rooms/data/storage/InMemoryDraftRoomStorage.kt
+++ b/shared/core-rooms/src/commonMain/kotlin/dev/nonoxy/residetrack/core/rooms/data/storage/InMemoryDraftRoomStorage.kt
@@ -1,0 +1,20 @@
+package dev.nonoxy.residetrack.core.rooms.data.storage
+
+import dev.nonoxy.residetrack.core.rooms.domain.model.Room
+import kotlinx.coroutines.flow.MutableStateFlow
+
+/** [DraftRoomStorage] backed by an in-memory [MutableStateFlow]. */
+internal class InMemoryDraftRoomStorage : DraftRoomStorage {
+
+    private val draft = MutableStateFlow<Room?>(null)
+
+    override fun save(room: Room) {
+        draft.value = room
+    }
+
+    override fun get(): Room? = draft.value
+
+    override fun clear() {
+        draft.value = null
+    }
+}

--- a/shared/core-rooms/src/commonMain/kotlin/dev/nonoxy/residetrack/core/rooms/di/CoreRoomsModule.kt
+++ b/shared/core-rooms/src/commonMain/kotlin/dev/nonoxy/residetrack/core/rooms/di/CoreRoomsModule.kt
@@ -1,10 +1,14 @@
 package dev.nonoxy.residetrack.core.rooms.di
 
+import dev.nonoxy.residetrack.core.rooms.data.DraftRoomRepositoryImpl
 import dev.nonoxy.residetrack.core.rooms.data.RoomsRepositoryImpl
+import dev.nonoxy.residetrack.core.rooms.data.storage.DraftRoomStorage
+import dev.nonoxy.residetrack.core.rooms.data.storage.InMemoryDraftRoomStorage
 import dev.nonoxy.residetrack.core.rooms.data.mappers.RoomMapper
 import dev.nonoxy.residetrack.core.rooms.data.mappers.RoomMapperImpl
 import dev.nonoxy.residetrack.core.rooms.data.mappers.StudentMapper
 import dev.nonoxy.residetrack.core.rooms.data.mappers.StudentMapperImpl
+import dev.nonoxy.residetrack.core.rooms.domain.repository.DraftRoomRepository
 import dev.nonoxy.residetrack.core.rooms.domain.repository.RoomsRepository
 import org.koin.core.module.dsl.factoryOf
 import org.koin.core.module.dsl.new
@@ -17,4 +21,8 @@ val coreRoomsModule = module {
     factory<RoomMapper> { new(::RoomMapperImpl) }
 
     single<RoomsRepository> { new(::RoomsRepositoryImpl) }
+
+    single<DraftRoomStorage> { InMemoryDraftRoomStorage() }
+
+    single<DraftRoomRepository> { new(::DraftRoomRepositoryImpl) }
 }

--- a/shared/core-rooms/src/commonMain/kotlin/dev/nonoxy/residetrack/core/rooms/domain/repository/DraftRoomRepository.kt
+++ b/shared/core-rooms/src/commonMain/kotlin/dev/nonoxy/residetrack/core/rooms/domain/repository/DraftRoomRepository.kt
@@ -1,0 +1,16 @@
+package dev.nonoxy.residetrack.core.rooms.domain.repository
+
+import dev.nonoxy.residetrack.core.rooms.domain.model.Room
+
+/**
+ * Handoff for the single room being drafted while add-room passes it to the
+ * editor. Backed by an in-memory store hidden behind this port.
+ */
+interface DraftRoomRepository {
+
+    suspend fun save(room: Room): Result<Unit>
+
+    suspend fun get(): Result<Room?>
+
+    suspend fun clear(): Result<Unit>
+}

--- a/shared/core-rooms/src/commonMain/kotlin/dev/nonoxy/residetrack/core/rooms/domain/repository/RoomsRepository.kt
+++ b/shared/core-rooms/src/commonMain/kotlin/dev/nonoxy/residetrack/core/rooms/domain/repository/RoomsRepository.kt
@@ -9,7 +9,6 @@ interface RoomsRepository {
     fun observeRooms(): Flow<List<Room>>
 
     suspend fun getAllRooms(): Result<List<Room>>
-    suspend fun getRoomByNumber(roomNumber: Int): Result<Room?>
     suspend fun getRoomById(roomId: Long): Result<Room?>
 
     suspend fun saveRoom(room: Room): Result<Long>
@@ -28,5 +27,4 @@ interface RoomsRepository {
     suspend fun saveDraftRoom(room: Room): Result<Unit>
     suspend fun getDraftRoom(): Result<Room?>
     suspend fun clearDraftRoom(): Result<Unit>
-    fun observeDraftRoom(): Flow<Room?>
 }

--- a/shared/core-rooms/src/commonMain/kotlin/dev/nonoxy/residetrack/core/rooms/domain/repository/RoomsRepository.kt
+++ b/shared/core-rooms/src/commonMain/kotlin/dev/nonoxy/residetrack/core/rooms/domain/repository/RoomsRepository.kt
@@ -23,8 +23,4 @@ interface RoomsRepository {
 
     /** Deletes the room and its students. */
     suspend fun deleteRoom(roomId: Long): Result<Unit>
-
-    suspend fun saveDraftRoom(room: Room): Result<Unit>
-    suspend fun getDraftRoom(): Result<Room?>
-    suspend fun clearDraftRoom(): Result<Unit>
 }

--- a/shared/feature-add-room/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/add_room/impl/di/FeatureAddRoomImplModule.kt
+++ b/shared/feature-add-room/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/add_room/impl/di/FeatureAddRoomImplModule.kt
@@ -12,6 +12,7 @@ val featureAddRoomImplModule = module {
             storeFactory = get(),
             mainDispatcher = get<CoroutineDispatchers>().main,
             roomsRepository = get(),
+            draftRoomRepository = get(),
         ).create()
     }
 }

--- a/shared/feature-add-room/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/add_room/impl/domain/AddRoomExecutor.kt
+++ b/shared/feature-add-room/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/add_room/impl/domain/AddRoomExecutor.kt
@@ -10,6 +10,7 @@ import dev.nonoxy.residetrack.feature.add_room.impl.domain.AddRoomStoreFactory.A
 import dev.nonoxy.residetrack.feature.add_room.impl.domain.AddRoomStoreFactory.AddRoomErrorKindOrNull
 import dev.nonoxy.residetrack.feature.add_room.impl.domain.AddRoomStoreFactory.Message
 import dev.nonoxy.residetrack.core.rooms.domain.model.Room
+import dev.nonoxy.residetrack.core.rooms.domain.repository.DraftRoomRepository
 import dev.nonoxy.residetrack.core.rooms.domain.repository.RoomsRepository
 import dev.nonoxy.residetrack.core.rooms.domain.validation.RoomNumberConflict
 import dev.nonoxy.residetrack.core.mvikotlin.BaseExecutor
@@ -18,6 +19,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 internal class AddRoomExecutor(
     mainDispatcher: CoroutineDispatcher,
     private val roomsRepository: RoomsRepository,
+    private val draftRoomRepository: DraftRoomRepository,
 ) : BaseExecutor<Intent, Action, State, Message, Label>(mainContext = mainDispatcher) {
 
     override suspend fun suspendExecuteAction(action: Action) {
@@ -168,7 +170,7 @@ internal class AddRoomExecutor(
         roomsRepository.saveRoom(newRoom).fold(
             onSuccess = { persistedId ->
                 val persistedRoom = newRoom.copy(id = persistedId)
-                roomsRepository.saveDraftRoom(persistedRoom).fold(
+                draftRoomRepository.save(persistedRoom).fold(
                     onSuccess = {
                         dispatch(Message.SetIsLoading(isLoading = false))
                         publish(Label.NavigateToRoomEditorDraftRoom)

--- a/shared/feature-add-room/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/add_room/impl/domain/AddRoomStoreFactory.kt
+++ b/shared/feature-add-room/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/add_room/impl/domain/AddRoomStoreFactory.kt
@@ -7,6 +7,7 @@ import dev.nonoxy.residetrack.feature.add_room.api.store.AddRoomStore
 import dev.nonoxy.residetrack.feature.add_room.api.store.AddRoomStore.Intent
 import dev.nonoxy.residetrack.feature.add_room.api.store.AddRoomStore.Label
 import dev.nonoxy.residetrack.feature.add_room.api.store.AddRoomStore.State
+import dev.nonoxy.residetrack.core.rooms.domain.repository.DraftRoomRepository
 import dev.nonoxy.residetrack.core.rooms.domain.repository.RoomsRepository
 import kotlinx.coroutines.CoroutineDispatcher
 
@@ -14,6 +15,7 @@ internal class AddRoomStoreFactory(
     private val storeFactory: StoreFactory,
     private val mainDispatcher: CoroutineDispatcher,
     private val roomsRepository: RoomsRepository,
+    private val draftRoomRepository: DraftRoomRepository,
 ) {
 
     fun create(): AddRoomStore =
@@ -27,6 +29,7 @@ internal class AddRoomStoreFactory(
                     AddRoomExecutor(
                         mainDispatcher = mainDispatcher,
                         roomsRepository = roomsRepository,
+                        draftRoomRepository = draftRoomRepository,
                     )
                 },
                 reducer = AddRoomReducer(),

--- a/shared/feature-add-room/impl/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/add_room/impl/data/FakeDraftRoomRepository.kt
+++ b/shared/feature-add-room/impl/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/add_room/impl/data/FakeDraftRoomRepository.kt
@@ -1,0 +1,32 @@
+package dev.nonoxy.residetrack.feature.add_room.impl.data
+
+import dev.nonoxy.residetrack.core.rooms.domain.model.Room
+import dev.nonoxy.residetrack.core.rooms.domain.repository.DraftRoomRepository
+
+/** Records the draft handoff so tests can assert what add-room saved. */
+internal class FakeDraftRoomRepository(
+    draftRoom: Room? = null,
+    private val saveResult: Result<Unit> = Result.success(Unit),
+) : DraftRoomRepository {
+
+    private var draft: Room? = draftRoom
+
+    var savedDraftRoom: Room? = null
+        private set
+    var clearCallCount: Int = 0
+        private set
+
+    override suspend fun save(room: Room): Result<Unit> {
+        savedDraftRoom = room
+        draft = room
+        return saveResult
+    }
+
+    override suspend fun get(): Result<Room?> = Result.success(draft)
+
+    override suspend fun clear(): Result<Unit> {
+        clearCallCount++
+        draft = null
+        return Result.success(Unit)
+    }
+}

--- a/shared/feature-add-room/impl/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/add_room/impl/data/FakeRoomsRepository.kt
+++ b/shared/feature-add-room/impl/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/add_room/impl/data/FakeRoomsRepository.kt
@@ -12,18 +12,14 @@ import kotlinx.coroutines.flow.flow
  */
 internal class FakeRoomsRepository(
     rooms: List<Room> = emptyList(),
-    draftRoom: Room? = null,
     private val getAllRoomsResult: Result<List<Room>>? = null,
     private val getRoomByIdResult: Result<Room?>? = null,
-    private val getDraftRoomResult: Result<Room?>? = null,
     private val saveRoomResult: Result<Long> = Result.success(DEFAULT_SAVED_ID),
-    private val saveDraftRoomResult: Result<Unit> = Result.success(Unit),
     private val updateRoomMetadataResult: Result<Unit> = Result.success(Unit),
     private val deleteRoomResult: Result<Unit> = Result.success(Unit),
 ) : RoomsRepository {
 
     private val roomsFlow = MutableStateFlow(rooms)
-    private val draftFlow = MutableStateFlow(draftRoom)
 
     /** When set, [observeRooms] emits this error instead of the rooms stream. */
     var observeRoomsError: Throwable? = null
@@ -31,10 +27,6 @@ internal class FakeRoomsRepository(
     var savedRoom: Room? = null
         private set
     var saveRoomCallCount: Int = 0
-        private set
-    var savedDraftRoom: Room? = null
-        private set
-    var clearDraftCallCount: Int = 0
         private set
     var deletedRoomId: Long? = null
         private set
@@ -46,9 +38,6 @@ internal class FakeRoomsRepository(
 
     override suspend fun getAllRooms(): Result<List<Room>> =
         getAllRoomsResult ?: Result.success(roomsFlow.value)
-
-    override suspend fun getRoomByNumber(roomNumber: Int): Result<Room?> =
-        Result.success(roomsFlow.value.firstOrNull { it.roomNumber == roomNumber })
 
     override suspend fun getRoomById(roomId: Long): Result<Room?> =
         getRoomByIdResult ?: Result.success(roomsFlow.value.firstOrNull { it.id == roomId })
@@ -73,22 +62,6 @@ internal class FakeRoomsRepository(
         deletedRoomId = roomId
         return deleteRoomResult
     }
-
-    override suspend fun saveDraftRoom(room: Room): Result<Unit> {
-        savedDraftRoom = room
-        return saveDraftRoomResult
-    }
-
-    override suspend fun getDraftRoom(): Result<Room?> =
-        getDraftRoomResult ?: Result.success(draftFlow.value)
-
-    override suspend fun clearDraftRoom(): Result<Unit> {
-        clearDraftCallCount++
-        draftFlow.value = null
-        return Result.success(Unit)
-    }
-
-    override fun observeDraftRoom(): Flow<Room?> = draftFlow
 
     data class Metadata(
         val roomId: Long,

--- a/shared/feature-add-room/impl/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/add_room/impl/domain/AddRoomExecutorTest.kt
+++ b/shared/feature-add-room/impl/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/add_room/impl/domain/AddRoomExecutorTest.kt
@@ -7,6 +7,7 @@ import dev.nonoxy.residetrack.feature.add_room.api.store.AddRoomErrorKind
 import dev.nonoxy.residetrack.feature.add_room.api.store.AddRoomStore
 import dev.nonoxy.residetrack.feature.add_room.api.store.AddRoomStore.Intent
 import dev.nonoxy.residetrack.feature.add_room.api.store.AddRoomStore.Label
+import dev.nonoxy.residetrack.feature.add_room.impl.data.FakeDraftRoomRepository
 import dev.nonoxy.residetrack.feature.add_room.impl.data.FakeRoomsRepository
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
@@ -26,11 +27,15 @@ class AddRoomExecutorTest {
     private fun room(id: Long, floor: Int, number: Int, beds: Int) =
         Room(id = id, floorNumber = floor, roomNumber = number, bedsCount = beds, students = emptyList())
 
-    private fun TestScope.createStore(repository: FakeRoomsRepository): AddRoomStore =
+    private fun TestScope.createStore(
+        repository: FakeRoomsRepository,
+        draftRepository: FakeDraftRoomRepository = FakeDraftRoomRepository(),
+    ): AddRoomStore =
         AddRoomStoreFactory(
             storeFactory = DefaultStoreFactory(),
             mainDispatcher = UnconfinedTestDispatcher(testScheduler),
             roomsRepository = repository,
+            draftRoomRepository = draftRepository,
         ).create()
 
     private fun TestScope.labelsOf(store: AddRoomStore): List<Label> {
@@ -144,7 +149,8 @@ class AddRoomExecutorTest {
     @Test
     fun `create success saves room and draft then navigates to draft editor`() = runTest {
         val repository = FakeRoomsRepository(saveRoomResult = Result.success(7L))
-        val store = createStore(repository)
+        val draftRepository = FakeDraftRoomRepository()
+        val store = createStore(repository, draftRepository)
         val labels = labelsOf(store)
 
         store.fillForm(floor = "1", roomNumber = "101", beds = "4")
@@ -155,7 +161,7 @@ class AddRoomExecutorTest {
         assertEquals(1, repository.savedRoom?.floorNumber)
         assertEquals(101, repository.savedRoom?.roomNumber)
         assertEquals(4, repository.savedRoom?.bedsCount)
-        assertEquals(7L, repository.savedDraftRoom?.id) // persisted id propagated into the draft
+        assertEquals(7L, draftRepository.savedDraftRoom?.id) // persisted id propagated into the draft
         assertTrue(labels.contains(Label.NavigateToRoomEditorDraftRoom))
         assertFalse(store.state.isLoading)
 

--- a/shared/feature-room-editor/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/impl/di/FeatureRoomEditorImplModule.kt
+++ b/shared/feature-room-editor/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/impl/di/FeatureRoomEditorImplModule.kt
@@ -14,6 +14,7 @@ val featureRoomEditorImplModule = module {
             storeFactory = get(),
             mainDispatcher = get<CoroutineDispatchers>().main,
             roomsRepository = get(),
+            draftRoomRepository = get(),
         ).create(mode = mode)
     } bind RoomEditorStore::class
 }

--- a/shared/feature-room-editor/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/impl/domain/RoomEditorExecutor.kt
+++ b/shared/feature-room-editor/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/impl/domain/RoomEditorExecutor.kt
@@ -4,6 +4,7 @@ import dev.nonoxy.residetrack.common.utils.currentLocalDate
 import dev.nonoxy.residetrack.core.mvikotlin.BaseExecutor
 import dev.nonoxy.residetrack.core.rooms.domain.model.Room
 import dev.nonoxy.residetrack.core.rooms.domain.model.Student
+import dev.nonoxy.residetrack.core.rooms.domain.repository.DraftRoomRepository
 import dev.nonoxy.residetrack.core.rooms.domain.repository.RoomsRepository
 import dev.nonoxy.residetrack.core.rooms.domain.validation.RoomNumberConflict
 import dev.nonoxy.residetrack.feature.room_editor.api.models.RoomEditorMode
@@ -30,6 +31,7 @@ import kotlin.uuid.Uuid
 internal class RoomEditorExecutor(
     mainDispatcher: CoroutineDispatcher,
     private val roomsRepository: RoomsRepository,
+    private val draftRoomRepository: DraftRoomRepository,
     private val mode: RoomEditorMode,
 ) : BaseExecutor<Intent, Action, State, Message, Label>(mainContext = mainDispatcher) {
 
@@ -94,7 +96,7 @@ internal class RoomEditorExecutor(
                     loadFromResult { roomsRepository.getRoomById(mode.roomId.toLong()) }
 
                 RoomEditorMode.DraftRoom ->
-                    loadFromResult { roomsRepository.getDraftRoom() }
+                    loadFromResult { draftRoomRepository.get() }
             }
         } catch (_: Exception) {
             dispatch(Message.SetError(kind = RoomEditorErrorKind.FailedToLoadStudents))
@@ -299,7 +301,7 @@ internal class RoomEditorExecutor(
     }
 
     private suspend fun saveDraft(currentRoom: Room, students: List<Student>) {
-        roomsRepository.getDraftRoom()
+        draftRoomRepository.get()
             .onSuccess { draftRoom ->
                 if (draftRoom == null) {
                     dispatch(Message.SetIsLoading(isLoading = false))
@@ -309,7 +311,7 @@ internal class RoomEditorExecutor(
                 val updated = draftRoom.copy(students = students)
                 roomsRepository.saveRoom(updated)
                     .onSuccess {
-                        roomsRepository.clearDraftRoom()
+                        draftRoomRepository.clear()
                         dispatch(Message.SetIsLoading(isLoading = false))
                         publish(Label.ShowSuccess(kind = RoomEditorSuccessKind.StudentsSaved))
                         publish(Label.NavigateBack)

--- a/shared/feature-room-editor/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/impl/domain/RoomEditorStoreFactory.kt
+++ b/shared/feature-room-editor/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/impl/domain/RoomEditorStoreFactory.kt
@@ -10,6 +10,7 @@ import dev.nonoxy.residetrack.feature.room_editor.api.store.RoomEditorStore.Inte
 import dev.nonoxy.residetrack.feature.room_editor.api.store.RoomEditorStore.Label
 import dev.nonoxy.residetrack.feature.room_editor.api.store.RoomEditorStore.State
 import dev.nonoxy.residetrack.core.rooms.domain.model.Room
+import dev.nonoxy.residetrack.core.rooms.domain.repository.DraftRoomRepository
 import dev.nonoxy.residetrack.core.rooms.domain.repository.RoomsRepository
 import kotlinx.coroutines.CoroutineDispatcher
 
@@ -17,6 +18,7 @@ internal class RoomEditorStoreFactory(
     private val storeFactory: StoreFactory,
     private val mainDispatcher: CoroutineDispatcher,
     private val roomsRepository: RoomsRepository,
+    private val draftRoomRepository: DraftRoomRepository,
 ) {
 
     fun create(mode: RoomEditorMode): RoomEditorStore =
@@ -30,6 +32,7 @@ internal class RoomEditorStoreFactory(
                     RoomEditorExecutor(
                         mainDispatcher = mainDispatcher,
                         roomsRepository = roomsRepository,
+                        draftRoomRepository = draftRoomRepository,
                         mode = mode,
                     )
                 },

--- a/shared/feature-room-editor/impl/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/room_editor/impl/data/FakeDraftRoomRepository.kt
+++ b/shared/feature-room-editor/impl/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/room_editor/impl/data/FakeDraftRoomRepository.kt
@@ -1,0 +1,32 @@
+package dev.nonoxy.residetrack.feature.room_editor.impl.data
+
+import dev.nonoxy.residetrack.core.rooms.domain.model.Room
+import dev.nonoxy.residetrack.core.rooms.domain.repository.DraftRoomRepository
+
+/** Serves a preset draft and records the clear so tests can assert the handoff. */
+internal class FakeDraftRoomRepository(
+    draftRoom: Room? = null,
+    private val getResult: Result<Room?>? = null,
+) : DraftRoomRepository {
+
+    private var draft: Room? = draftRoom
+
+    var savedDraftRoom: Room? = null
+        private set
+    var clearCallCount: Int = 0
+        private set
+
+    override suspend fun save(room: Room): Result<Unit> {
+        savedDraftRoom = room
+        draft = room
+        return Result.success(Unit)
+    }
+
+    override suspend fun get(): Result<Room?> = getResult ?: Result.success(draft)
+
+    override suspend fun clear(): Result<Unit> {
+        clearCallCount++
+        draft = null
+        return Result.success(Unit)
+    }
+}

--- a/shared/feature-room-editor/impl/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/room_editor/impl/data/FakeRoomsRepository.kt
+++ b/shared/feature-room-editor/impl/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/room_editor/impl/data/FakeRoomsRepository.kt
@@ -12,18 +12,14 @@ import kotlinx.coroutines.flow.flow
  */
 internal class FakeRoomsRepository(
     rooms: List<Room> = emptyList(),
-    draftRoom: Room? = null,
     private val getAllRoomsResult: Result<List<Room>>? = null,
     private val getRoomByIdResult: Result<Room?>? = null,
-    private val getDraftRoomResult: Result<Room?>? = null,
     private val saveRoomResult: Result<Long> = Result.success(DEFAULT_SAVED_ID),
-    private val saveDraftRoomResult: Result<Unit> = Result.success(Unit),
     private val updateRoomMetadataResult: Result<Unit> = Result.success(Unit),
     private val deleteRoomResult: Result<Unit> = Result.success(Unit),
 ) : RoomsRepository {
 
     private val roomsFlow = MutableStateFlow(rooms)
-    private val draftFlow = MutableStateFlow(draftRoom)
 
     /** When set, [observeRooms] emits this error instead of the rooms stream. */
     var observeRoomsError: Throwable? = null
@@ -31,10 +27,6 @@ internal class FakeRoomsRepository(
     var savedRoom: Room? = null
         private set
     var saveRoomCallCount: Int = 0
-        private set
-    var savedDraftRoom: Room? = null
-        private set
-    var clearDraftCallCount: Int = 0
         private set
     var deletedRoomId: Long? = null
         private set
@@ -46,9 +38,6 @@ internal class FakeRoomsRepository(
 
     override suspend fun getAllRooms(): Result<List<Room>> =
         getAllRoomsResult ?: Result.success(roomsFlow.value)
-
-    override suspend fun getRoomByNumber(roomNumber: Int): Result<Room?> =
-        Result.success(roomsFlow.value.firstOrNull { it.roomNumber == roomNumber })
 
     override suspend fun getRoomById(roomId: Long): Result<Room?> =
         getRoomByIdResult ?: Result.success(roomsFlow.value.firstOrNull { it.id == roomId })
@@ -73,22 +62,6 @@ internal class FakeRoomsRepository(
         deletedRoomId = roomId
         return deleteRoomResult
     }
-
-    override suspend fun saveDraftRoom(room: Room): Result<Unit> {
-        savedDraftRoom = room
-        return saveDraftRoomResult
-    }
-
-    override suspend fun getDraftRoom(): Result<Room?> =
-        getDraftRoomResult ?: Result.success(draftFlow.value)
-
-    override suspend fun clearDraftRoom(): Result<Unit> {
-        clearDraftCallCount++
-        draftFlow.value = null
-        return Result.success(Unit)
-    }
-
-    override fun observeDraftRoom(): Flow<Room?> = draftFlow
 
     data class Metadata(
         val roomId: Long,

--- a/shared/feature-room-editor/impl/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/room_editor/impl/domain/RoomEditorExecutorTest.kt
+++ b/shared/feature-room-editor/impl/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/room_editor/impl/domain/RoomEditorExecutorTest.kt
@@ -10,6 +10,7 @@ import dev.nonoxy.residetrack.feature.room_editor.api.store.RoomEditorStore
 import dev.nonoxy.residetrack.feature.room_editor.api.store.RoomEditorStore.Intent
 import dev.nonoxy.residetrack.feature.room_editor.api.store.RoomEditorStore.Label
 import dev.nonoxy.residetrack.feature.room_editor.api.store.RoomEditorSuccessKind
+import dev.nonoxy.residetrack.feature.room_editor.impl.data.FakeDraftRoomRepository
 import dev.nonoxy.residetrack.feature.room_editor.impl.data.FakeRoomsRepository
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
@@ -52,10 +53,12 @@ class RoomEditorExecutorTest {
     private fun TestScope.createStore(
         repository: FakeRoomsRepository,
         mode: RoomEditorMode,
+        draftRepository: FakeDraftRoomRepository = FakeDraftRoomRepository(),
     ): RoomEditorStore = RoomEditorStoreFactory(
         storeFactory = DefaultStoreFactory(),
         mainDispatcher = UnconfinedTestDispatcher(testScheduler),
         roomsRepository = repository,
+        draftRoomRepository = draftRepository,
     ).create(mode = mode)
 
     private fun TestScope.labelsOf(store: RoomEditorStore): List<Label> {
@@ -231,17 +234,18 @@ class RoomEditorExecutorTest {
 
     @Test
     fun `save draft persists students clears the draft and navigates back`() = runTest {
-        val repository = FakeRoomsRepository(
+        val repository = FakeRoomsRepository()
+        val draftRepository = FakeDraftRoomRepository(
             draftRoom = room(id = 9, floor = 1, number = 101, students = listOf(student(id = 0, stream = 305))),
         )
-        val store = createStore(repository, RoomEditorMode.DraftRoom)
+        val store = createStore(repository, RoomEditorMode.DraftRoom, draftRepository)
         val labels = labelsOf(store)
 
         store.accept(Intent.OnSaveAndClose)
         advanceUntilIdle()
 
         assertEquals(1, repository.saveRoomCallCount)
-        assertEquals(1, repository.clearDraftCallCount)
+        assertEquals(1, draftRepository.clearCallCount)
         assertEquals(listOf(305), repository.savedRoom?.students?.map { it.streamNumber })
         assertTrue(labels.contains(Label.NavigateBack))
 
@@ -333,8 +337,9 @@ class RoomEditorExecutorTest {
 
     @Test
     fun `room params and delete are no-ops in draft mode`() = runTest {
-        val repository = FakeRoomsRepository(draftRoom = room(id = 9, students = emptyList()))
-        val store = createStore(repository, RoomEditorMode.DraftRoom)
+        val repository = FakeRoomsRepository()
+        val draftRepository = FakeDraftRoomRepository(draftRoom = room(id = 9, students = emptyList()))
+        val store = createStore(repository, RoomEditorMode.DraftRoom, draftRepository)
 
         store.accept(Intent.OnSaveRoomParams)
         store.accept(Intent.OnDeleteRoomConfirm)

--- a/shared/feature-rooms/impl/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/data/FakeRoomsRepository.kt
+++ b/shared/feature-rooms/impl/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/rooms/impl/data/FakeRoomsRepository.kt
@@ -12,18 +12,14 @@ import kotlinx.coroutines.flow.flow
  */
 internal class FakeRoomsRepository(
     rooms: List<Room> = emptyList(),
-    draftRoom: Room? = null,
     private val getAllRoomsResult: Result<List<Room>>? = null,
     private val getRoomByIdResult: Result<Room?>? = null,
-    private val getDraftRoomResult: Result<Room?>? = null,
     private val saveRoomResult: Result<Long> = Result.success(DEFAULT_SAVED_ID),
-    private val saveDraftRoomResult: Result<Unit> = Result.success(Unit),
     private val updateRoomMetadataResult: Result<Unit> = Result.success(Unit),
     private val deleteRoomResult: Result<Unit> = Result.success(Unit),
 ) : RoomsRepository {
 
     private val roomsFlow = MutableStateFlow(rooms)
-    private val draftFlow = MutableStateFlow(draftRoom)
 
     /** When set, [observeRooms] emits this error instead of the rooms stream. */
     var observeRoomsError: Throwable? = null
@@ -31,10 +27,6 @@ internal class FakeRoomsRepository(
     var savedRoom: Room? = null
         private set
     var saveRoomCallCount: Int = 0
-        private set
-    var savedDraftRoom: Room? = null
-        private set
-    var clearDraftCallCount: Int = 0
         private set
     var deletedRoomId: Long? = null
         private set
@@ -46,9 +38,6 @@ internal class FakeRoomsRepository(
 
     override suspend fun getAllRooms(): Result<List<Room>> =
         getAllRoomsResult ?: Result.success(roomsFlow.value)
-
-    override suspend fun getRoomByNumber(roomNumber: Int): Result<Room?> =
-        Result.success(roomsFlow.value.firstOrNull { it.roomNumber == roomNumber })
 
     override suspend fun getRoomById(roomId: Long): Result<Room?> =
         getRoomByIdResult ?: Result.success(roomsFlow.value.firstOrNull { it.id == roomId })
@@ -73,22 +62,6 @@ internal class FakeRoomsRepository(
         deletedRoomId = roomId
         return deleteRoomResult
     }
-
-    override suspend fun saveDraftRoom(room: Room): Result<Unit> {
-        savedDraftRoom = room
-        return saveDraftRoomResult
-    }
-
-    override suspend fun getDraftRoom(): Result<Room?> =
-        getDraftRoomResult ?: Result.success(draftFlow.value)
-
-    override suspend fun clearDraftRoom(): Result<Unit> {
-        clearDraftCallCount++
-        draftFlow.value = null
-        return Result.success(Unit)
-    }
-
-    override fun observeDraftRoom(): Flow<Room?> = draftFlow
 
     data class Metadata(
         val roomId: Long,


### PR DESCRIPTION
Decompose the RoomsRepository god-object:
- Remove dead methods (`getRoomByNumber`, `observeDraftRoom`).
- Extract the transient draft-room handoff into its own port `DraftRoomRepository` (Result-returning, injected into add-room and room-editor executors), backed by `data/storage/DraftRoomStorage` + `InMemoryDraftRoomStorage` (plain in-memory holder, no Result — the repository wraps it).
- RoomsRepository is left as cohesive rooms-CRUD.

Merge note: touches AddRoomExecutor and RoomEditorExecutor — if the add-room/room-editor immutable PRs land first, rebase this one.