### PR TITLE
feat(upcoming): redesign checkout card

### DIFF
--- a/shared/common-resources/src/commonMain/moko-resources/base/strings.xml
+++ b/shared/common-resources/src/commonMain/moko-resources/base/strings.xml
@@ -103,9 +103,12 @@
     <string name="upcoming_bucket_overdue">Просрочено</string>
     <string name="upcoming_bucket_today_tomorrow">Сегодня — завтра</string>
     <string name="upcoming_bucket_this_week">На этой неделе</string>
-    <string name="upcoming_room_label">%1$s · эт. %2$s</string>
+    <string name="upcoming_room_number">Комната %1$s</string>
+    <string name="upcoming_floor">Этаж %1$s</string>
     <string name="upcoming_days_left">Осталось дней: %1$s</string>
     <string name="upcoming_days_overdue">Просрочено на %1$s дн.</string>
+    <string name="upcoming_months_overdue">Просрочено на %1$s мес.</string>
+    <string name="upcoming_years_overdue">Просрочено на %1$s г.</string>
     <string name="rooms_tab">Комнаты</string>
     <string name="action_retry">Повторить</string>
 

--- a/shared/common-ui/src/commonMain/kotlin/dev/nonoxy/residetrack/common/ui/theme/Sizes.kt
+++ b/shared/common-ui/src/commonMain/kotlin/dev/nonoxy/residetrack/common/ui/theme/Sizes.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.unit.dp
 
 val size_1: Dp = 1.dp
 val size_4: Dp = 4.dp
+val size_16: Dp = 16.dp
 val size_20: Dp = 20.dp
 val size_24: Dp = 24.dp
 val size_28: Dp = 28.dp

--- a/shared/feature-upcoming/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/upcoming/presentation/mappers/UiUpcomingStateMapper.kt
+++ b/shared/feature-upcoming/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/upcoming/presentation/mappers/UiUpcomingStateMapper.kt
@@ -2,10 +2,14 @@ package dev.nonoxy.residetrack.feature.upcoming.presentation.mappers
 
 import dev.nonoxy.residetrack.core.rooms.domain.upcoming.UpcomingBucket
 import dev.nonoxy.residetrack.feature.upcoming.api.store.UpcomingStore
+import dev.nonoxy.residetrack.feature.upcoming.presentation.models.UiDaysBadge
+import dev.nonoxy.residetrack.feature.upcoming.presentation.models.UiOverdueUnit
 import dev.nonoxy.residetrack.feature.upcoming.presentation.models.UiUpcomingBucket
 import dev.nonoxy.residetrack.feature.upcoming.presentation.models.UiUpcomingItem
 import dev.nonoxy.residetrack.feature.upcoming.presentation.models.UiUpcomingState
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.format.char
 
 internal interface UiUpcomingStateMapper {
     fun map(item: UpcomingStore.State): UiUpcomingState
@@ -22,16 +26,39 @@ internal class UiUpcomingStateMapperImpl : UiUpcomingStateMapper {
                 roomNumber = domain.roomNumber.toString(),
                 floorNumber = domain.floorNumber.toString(),
                 streamNumber = domain.streamNumber.toString(),
-                checkOutDate = domain.checkOutDate.toString(),
-                daysLeft = domain.daysLeft,
+                checkOutDate = DISPLAY_DATE.format(domain.checkOutDate),
+                daysBadge = daysBadge(domain.daysLeft),
                 bucket = domain.bucket.toUi(),
             )
         }.toImmutableList(),
     )
 
+    private fun daysBadge(daysLeft: Int): UiDaysBadge {
+        if (daysLeft >= 0) return UiDaysBadge.Remaining(days = daysLeft)
+        val overdue = -daysLeft
+        return when {
+            overdue >= DAYS_IN_YEAR -> UiDaysBadge.Overdue(overdue / DAYS_IN_YEAR, UiOverdueUnit.YEARS)
+            overdue >= DAYS_IN_MONTH -> UiDaysBadge.Overdue(overdue / DAYS_IN_MONTH, UiOverdueUnit.MONTHS)
+            else -> UiDaysBadge.Overdue(overdue, UiOverdueUnit.DAYS)
+        }
+    }
+
     private fun UpcomingBucket.toUi(): UiUpcomingBucket = when (this) {
         UpcomingBucket.OVERDUE -> UiUpcomingBucket.OVERDUE
         UpcomingBucket.TODAY_TOMORROW -> UiUpcomingBucket.TODAY_TOMORROW
         UpcomingBucket.THIS_WEEK -> UiUpcomingBucket.THIS_WEEK
+    }
+
+    private companion object {
+        const val DAYS_IN_MONTH = 30
+        const val DAYS_IN_YEAR = 365
+
+        val DISPLAY_DATE = LocalDate.Format {
+            dayOfMonth()
+            char('.')
+            monthNumber()
+            char('.')
+            year()
+        }
     }
 }

--- a/shared/feature-upcoming/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/upcoming/presentation/models/UiDaysBadge.kt
+++ b/shared/feature-upcoming/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/upcoming/presentation/models/UiDaysBadge.kt
@@ -1,0 +1,14 @@
+package dev.nonoxy.residetrack.feature.upcoming.presentation.models
+
+/**
+ * Готовое для показа значение бейджа. Для просрочки единица (дни/месяцы/годы) выбирается в
+ * presentation по величине, чтобы бейдж оставался коротким даже при просрочке на месяцы/годы.
+ */
+sealed interface UiDaysBadge {
+
+    data class Remaining(val days: Int) : UiDaysBadge
+
+    data class Overdue(val amount: Int, val unit: UiOverdueUnit) : UiDaysBadge
+}
+
+enum class UiOverdueUnit { DAYS, MONTHS, YEARS }

--- a/shared/feature-upcoming/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/upcoming/presentation/models/UiUpcomingItem.kt
+++ b/shared/feature-upcoming/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/upcoming/presentation/models/UiUpcomingItem.kt
@@ -1,24 +1,11 @@
 package dev.nonoxy.residetrack.feature.upcoming.presentation.models
 
-import dev.icerock.moko.resources.StringResource
-import dev.nonoxy.residetrack.res.MR
-
 data class UiUpcomingItem(
     val roomId: Long,
     val roomNumber: String,
     val floorNumber: String,
     val streamNumber: String,
-    val checkOutDate: String, // ISO-8601
-    val daysLeft: Int,
+    val checkOutDate: String,
+    val daysBadge: UiDaysBadge,
     val bucket: UiUpcomingBucket,
-) {
-
-    // Computed, not constructor args: keeps the model free of moko-resources at construction
-    // so pure mapping logic (and its native unit tests) never trigger MR class init, mirroring
-    // UiUpcomingBucket.title. The overdue/left choice is presentation logic, not UI's to decide.
-    val daysLeftValue: String
-        get() = if (daysLeft < 0) (-daysLeft).toString() else daysLeft.toString()
-
-    val daysLeftLabel: StringResource
-        get() = if (daysLeft < 0) MR.strings.upcoming_days_overdue else MR.strings.upcoming_days_left
-}
+)

--- a/shared/feature-upcoming/presentation/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/upcoming/presentation/mappers/UiUpcomingStateMapperTest.kt
+++ b/shared/feature-upcoming/presentation/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/upcoming/presentation/mappers/UiUpcomingStateMapperTest.kt
@@ -3,6 +3,8 @@ package dev.nonoxy.residetrack.feature.upcoming.presentation.mappers
 import dev.nonoxy.residetrack.core.rooms.domain.upcoming.UpcomingBucket
 import dev.nonoxy.residetrack.feature.upcoming.api.models.UpcomingItem
 import dev.nonoxy.residetrack.feature.upcoming.api.store.UpcomingStore
+import dev.nonoxy.residetrack.feature.upcoming.presentation.models.UiDaysBadge
+import dev.nonoxy.residetrack.feature.upcoming.presentation.models.UiOverdueUnit
 import dev.nonoxy.residetrack.feature.upcoming.presentation.models.UiUpcomingBucket
 import kotlinx.datetime.LocalDate
 import kotlin.test.Test
@@ -13,60 +15,70 @@ class UiUpcomingStateMapperTest {
     private val mapper: UiUpcomingStateMapper = UiUpcomingStateMapperImpl()
 
     @Test
-    fun mapsDomainItemsToUiWithRoomLabel() {
-        val state = UpcomingStore.State(
-            isLoading = false,
-            isError = false,
-            items = listOf(
-                UpcomingItem(
-                    roomId = 7,
-                    floorNumber = 2,
-                    roomNumber = 14,
-                    studentId = 10,
-                    streamNumber = 305,
-                    checkOutDate = LocalDate(2026, 6, 1),
-                    daysLeft = -3,
-                    bucket = UpcomingBucket.OVERDUE,
-                )
-            ),
-        )
-
-        val ui = mapper.map(state)
+    fun mapsDomainItemsToUiFields() {
+        val ui = mapper.map(stateWith(daysLeft = -3))
 
         assertEquals(1, ui.items.size)
         val item = ui.items.first()
         assertEquals("14", item.roomNumber)
         assertEquals("2", item.floorNumber)
         assertEquals("305", item.streamNumber)
-        assertEquals("2026-06-01", item.checkOutDate)
-        assertEquals(-3, item.daysLeft)
-        assertEquals("3", item.daysLeftValue)
+
         assertEquals(UiUpcomingBucket.OVERDUE, item.bucket)
     }
 
     @Test
-    fun daysLeftValueDropsSignForOverdueAndKeepsItForUpcoming() {
-        val state = UpcomingStore.State(
-            items = listOf(
-                upcomingItem(daysLeft = -3, bucket = UpcomingBucket.OVERDUE),
-                upcomingItem(daysLeft = 5, bucket = UpcomingBucket.THIS_WEEK),
-            ),
-        )
+    fun formatsCheckOutDateAsDayMonthYearWithPadding() {
+        val ui = mapper.map(stateWith(daysLeft = -3, checkOutDate = LocalDate(2026, 6, 1)))
 
-        val ui = mapper.map(state)
-
-        assertEquals("3", ui.items[0].daysLeftValue)
-        assertEquals("5", ui.items[1].daysLeftValue)
+        assertEquals("01.06.2026", ui.items.first().checkOutDate)
     }
 
-    private fun upcomingItem(daysLeft: Int, bucket: UpcomingBucket) = UpcomingItem(
-        roomId = 7,
-        floorNumber = 2,
-        roomNumber = 14,
-        studentId = 10,
-        streamNumber = 305,
-        checkOutDate = LocalDate(2026, 6, 1),
-        daysLeft = daysLeft,
-        bucket = bucket,
+    @Test
+    fun buildsRemainingBadgeForFutureCheckout() {
+        val badge = mapper.map(stateWith(daysLeft = 5)).items.first().daysBadge
+
+        assertEquals(UiDaysBadge.Remaining(days = 5), badge)
+    }
+
+    @Test
+    fun buildsOverdueBadgeInDaysBelowOneMonth() {
+        val badge = mapper.map(stateWith(daysLeft = -3)).items.first().daysBadge
+
+        assertEquals(UiDaysBadge.Overdue(amount = 3, unit = UiOverdueUnit.DAYS), badge)
+    }
+
+    @Test
+    fun buildsOverdueBadgeInMonthsFromThirtyDays() {
+        val badge = mapper.map(stateWith(daysLeft = -45)).items.first().daysBadge
+
+        assertEquals(UiDaysBadge.Overdue(amount = 1, unit = UiOverdueUnit.MONTHS), badge)
+    }
+
+    @Test
+    fun buildsOverdueBadgeInYearsFromThreeHundredSixtyFiveDays() {
+        val badge = mapper.map(stateWith(daysLeft = -400)).items.first().daysBadge
+
+        assertEquals(UiDaysBadge.Overdue(amount = 1, unit = UiOverdueUnit.YEARS), badge)
+    }
+
+    private fun stateWith(
+        daysLeft: Int,
+        checkOutDate: LocalDate = LocalDate(2026, 6, 1),
+    ) = UpcomingStore.State(
+        isLoading = false,
+        isError = false,
+        items = listOf(
+            UpcomingItem(
+                roomId = 7,
+                floorNumber = 2,
+                roomNumber = 14,
+                studentId = 10,
+                streamNumber = 305,
+                checkOutDate = checkOutDate,
+                daysLeft = daysLeft,
+                bucket = UpcomingBucket.OVERDUE,
+            ),
+        ),
     )
 }

--- a/shared/feature-upcoming/ui/build.gradle.kts
+++ b/shared/feature-upcoming/ui/build.gradle.kts
@@ -15,5 +15,6 @@ androidLibraryConfig {
 commonMainDependencies {
     implementations(
         libs.kotlin.immutableCollections,
+        libs.compose.icons.core,
     )
 }

--- a/shared/feature-upcoming/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/upcoming/ui/views/UpcomingListItem.kt
+++ b/shared/feature-upcoming/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/upcoming/ui/views/UpcomingListItem.kt
@@ -10,19 +10,27 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DateRange
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import dev.icerock.moko.resources.StringResource
+import androidx.compose.ui.text.style.TextOverflow
 import dev.icerock.moko.resources.compose.stringResource
 import dev.nonoxy.residetrack.common.ui.theme.ResideTrackTheme
 import dev.nonoxy.residetrack.common.ui.theme.padding_size_10
 import dev.nonoxy.residetrack.common.ui.theme.padding_size_12
 import dev.nonoxy.residetrack.common.ui.theme.padding_size_2
 import dev.nonoxy.residetrack.common.ui.theme.padding_size_4
+import dev.nonoxy.residetrack.common.ui.theme.padding_size_6
+import dev.nonoxy.residetrack.common.ui.theme.size_16
+import dev.nonoxy.residetrack.feature.upcoming.presentation.models.UiDaysBadge
+import dev.nonoxy.residetrack.feature.upcoming.presentation.models.UiOverdueUnit
 import dev.nonoxy.residetrack.feature.upcoming.presentation.models.UiUpcomingBucket
 import dev.nonoxy.residetrack.feature.upcoming.presentation.models.UiUpcomingItem
 import dev.nonoxy.residetrack.res.MR
@@ -45,39 +53,77 @@ internal fun UpcomingListItem(
     ) {
         Column(modifier = Modifier.weight(1f)) {
             Text(
-                text = stringResource(MR.strings.upcoming_room_label, item.roomNumber, item.floorNumber),
+                text = stringResource(MR.strings.upcoming_room_number, item.roomNumber),
                 style = ResideTrackTheme.typography.head3,
+                color = ResideTrackTheme.colors.textBody,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Spacer(modifier = Modifier.height(padding_size_2))
+            Text(
+                text = stringResource(MR.strings.upcoming_floor, item.floorNumber),
+                style = ResideTrackTheme.typography.paragraph,
                 color = ResideTrackTheme.colors.textBody,
             )
             Spacer(modifier = Modifier.height(padding_size_2))
             Text(
                 text = "${stringResource(MR.strings.rooms_stream)} ${item.streamNumber}",
-                style = ResideTrackTheme.typography.paragraph,
-                color = ResideTrackTheme.colors.textCaption,
-            )
-            Text(
-                text = item.checkOutDate,
                 style = ResideTrackTheme.typography.caption,
                 color = ResideTrackTheme.colors.textCaption,
             )
         }
 
-        DaysLeftBadge(
+        Column(
             modifier = Modifier.padding(start = padding_size_10),
-            label = item.daysLeftLabel,
-            labelValue = item.daysLeftValue,
-            bucket = item.bucket,
+            horizontalAlignment = Alignment.End,
+        ) {
+            DaysLeftBadge(daysBadge = item.daysBadge, bucket = item.bucket)
+            Spacer(modifier = Modifier.height(padding_size_6))
+            CheckOutDate(date = item.checkOutDate)
+        }
+    }
+}
+
+@Composable
+private fun CheckOutDate(
+    date: String,
+    modifier: Modifier = Modifier,
+) {
+    Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
+        Icon(
+            modifier = Modifier.size(size_16),
+            imageVector = Icons.Filled.DateRange,
+            contentDescription = null,
+            tint = ResideTrackTheme.colors.textCaption,
+        )
+        Spacer(modifier = Modifier.size(padding_size_4))
+        Text(
+            text = date,
+            style = ResideTrackTheme.typography.paragraph,
+            color = ResideTrackTheme.colors.textBody,
         )
     }
 }
 
 @Composable
 private fun DaysLeftBadge(
-    label: StringResource,
-    labelValue: String,
+    daysBadge: UiDaysBadge,
     bucket: UiUpcomingBucket,
     modifier: Modifier = Modifier,
 ) {
+    val text = when (daysBadge) {
+        is UiDaysBadge.Remaining ->
+            stringResource(MR.strings.upcoming_days_left, daysBadge.days.toString())
+
+        is UiDaysBadge.Overdue -> {
+            val resource = when (daysBadge.unit) {
+                UiOverdueUnit.DAYS -> MR.strings.upcoming_days_overdue
+                UiOverdueUnit.MONTHS -> MR.strings.upcoming_months_overdue
+                UiOverdueUnit.YEARS -> MR.strings.upcoming_years_overdue
+            }
+            stringResource(resource, daysBadge.amount.toString())
+        }
+    }
     val backgroundColor = when (bucket) {
         UiUpcomingBucket.OVERDUE -> ResideTrackTheme.colors.fillErrorBGSecondary
         UiUpcomingBucket.TODAY_TOMORROW -> ResideTrackTheme.colors.fillWarningBGSecondary
@@ -93,7 +139,7 @@ private fun DaysLeftBadge(
             .clip(ResideTrackTheme.shapes.cornerRadius20)
             .background(backgroundColor)
             .padding(horizontal = padding_size_10, vertical = padding_size_4),
-        text = stringResource(label, labelValue),
+        text = text,
         style = ResideTrackTheme.typography.head5,
         color = textColor,
     )
@@ -116,8 +162,8 @@ private fun Preview() {
                     roomNumber = "329",
                     floorNumber = "3",
                     streamNumber = "1234",
-                    checkOutDate = "2024-03-31",
-                    daysLeft = -2,
+                    checkOutDate = "31.03.2024",
+                    daysBadge = UiDaysBadge.Overdue(amount = 2, unit = UiOverdueUnit.DAYS),
                     bucket = UiUpcomingBucket.OVERDUE,
                 ),
                 onClick = {}
@@ -129,8 +175,8 @@ private fun Preview() {
                     roomNumber = "401",
                     floorNumber = "4",
                     streamNumber = "5646",
-                    checkOutDate = "2024-04-02",
-                    daysLeft = 1,
+                    checkOutDate = "02.04.2024",
+                    daysBadge = UiDaysBadge.Remaining(days = 1),
                     bucket = UiUpcomingBucket.TODAY_TOMORROW,
                 ),
                 onClick = {}
@@ -142,9 +188,9 @@ private fun Preview() {
                     roomNumber = "215",
                     floorNumber = "2",
                     streamNumber = "7777",
-                    checkOutDate = "2024-04-06",
-                    daysLeft = 5,
-                    bucket = UiUpcomingBucket.THIS_WEEK,
+                    checkOutDate = "06.04.2023",
+                    daysBadge = UiDaysBadge.Overdue(amount = 1, unit = UiOverdueUnit.YEARS),
+                    bucket = UiUpcomingBucket.OVERDUE,
                 ),
                 onClick = {}
             )

--- a/shared/feature-upcoming/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/upcoming/ui/views/UpcomingScreenDetails.kt
+++ b/shared/feature-upcoming/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/upcoming/ui/views/UpcomingScreenDetails.kt
@@ -5,6 +5,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import dev.nonoxy.residetrack.common.ui.common.state.ShowStateData
 import dev.nonoxy.residetrack.common.ui.theme.ResideTrackTheme
+import dev.nonoxy.residetrack.feature.upcoming.presentation.models.UiDaysBadge
+import dev.nonoxy.residetrack.feature.upcoming.presentation.models.UiOverdueUnit
 import dev.nonoxy.residetrack.feature.upcoming.presentation.models.UiUpcomingBucket
 import dev.nonoxy.residetrack.feature.upcoming.presentation.models.UiUpcomingItem
 import dev.nonoxy.residetrack.feature.upcoming.presentation.models.UiUpcomingState
@@ -50,8 +52,8 @@ private fun Preview() {
                         roomNumber = "329",
                         floorNumber = "3",
                         streamNumber = "1234",
-                        checkOutDate = "2024-03-31",
-                        daysLeft = -2,
+                        checkOutDate = "31.03.2024",
+                        daysBadge = UiDaysBadge.Overdue(amount = 2, unit = UiOverdueUnit.DAYS),
                         bucket = UiUpcomingBucket.OVERDUE,
                     ),
                     UiUpcomingItem(
@@ -59,8 +61,8 @@ private fun Preview() {
                         roomNumber = "401",
                         floorNumber = "4",
                         streamNumber = "5646",
-                        checkOutDate = "2024-04-02",
-                        daysLeft = 1,
+                        checkOutDate = "02.04.2024",
+                        daysBadge = UiDaysBadge.Remaining(days = 1),
                         bucket = UiUpcomingBucket.TODAY_TOMORROW,
                     ),
                 )


### PR DESCRIPTION
Переработка карточки на табе «Скоро».

- идентичность комнаты разбита на строки `Комната N` (head3) + `Этаж M` (paragraph), `·` убран
- дата выезда форматируется как dd.MM.yyyy (как везде в приложении) вместо сырого ISO, вынесена в тайм-кластер с иконкой календаря рядом с бейджем и поднята до читаемого стиля
- бейдж просрочки сворачивается в крупные единицы (дни → месяцы → годы), чтобы не разрастаться при просрочке на месяцы/годы; выбор единицы — в presentation-маппере через `UiDaysBadge`

Покрыто тестами маппера (дни/месяцы/годы + формат даты).