### PR TITLE
fix(room-editor): delete room not working

### DIFF
--- a/shared/feature-room-editor/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/impl/domain/RoomEditorExecutor.kt
+++ b/shared/feature-room-editor/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/impl/domain/RoomEditorExecutor.kt
@@ -82,7 +82,12 @@ internal class RoomEditorExecutor(
 
             is Intent.OnRoomParamsBedsChange -> updateRoomParam { it.copy(bedsCount = digits(intent.value)) }
             Intent.OnSaveRoomParams -> handleSaveRoomParams()
-            Intent.OnDeleteRoomClick -> dispatch(Message.SetShowDeleteConfirm(show = true))
+            Intent.OnDeleteRoomClick -> {
+                // Закрываем sheet параметров перед показом диалога: ModalBottomSheet — отдельное
+                // окно поверх, иначе диалог подтверждения оказывается за ним и недоступен для тапа.
+                dispatch(Message.SetShowRoomParams(show = false))
+                dispatch(Message.SetShowDeleteConfirm(show = true))
+            }
             Intent.OnDeleteRoomDismiss -> dispatch(Message.SetShowDeleteConfirm(show = false))
             Intent.OnDeleteRoomConfirm -> handleDeleteRoom()
         }


### PR DESCRIPTION
Диалог подтверждения удаления открывался, пока ещё был виден sheet параметров (ModalBottomSheet). При двух окнах Android кладёт sheet поверх диалога — кнопка подтверждения оказывается за sheet и не получает тап, удаление визуально не срабатывало.

Фикс: закрываем sheet при открытии диалога подтверждения, чтобы он рендерился сверху.