### PR TITLE
fix(core-rooms): дубли комнат при сохранении

### DIFF
--- a/shared/core-rooms/src/commonMain/kotlin/dev/nonoxy/residetrack/core/rooms/data/mappers/RoomMapper.kt
+++ b/shared/core-rooms/src/commonMain/kotlin/dev/nonoxy/residetrack/core/rooms/data/mappers/RoomMapper.kt
@@ -25,6 +25,7 @@ internal class RoomMapperImpl(
 
     override fun map(item: Room): RoomEntity = with(item) {
         RoomEntity(
+            id = id,
             floorNumber = floorNumber,
             roomNumber = roomNumber,
             bedsCount = bedsCount

--- a/shared/core-rooms/src/commonTest/kotlin/dev/nonoxy/residetrack/core/rooms/data/mappers/RoomMapperImplTest.kt
+++ b/shared/core-rooms/src/commonTest/kotlin/dev/nonoxy/residetrack/core/rooms/data/mappers/RoomMapperImplTest.kt
@@ -1,0 +1,22 @@
+package dev.nonoxy.residetrack.core.rooms.data.mappers
+
+import dev.nonoxy.residetrack.core.rooms.domain.model.Room
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class RoomMapperImplTest {
+
+    private val mapper = RoomMapperImpl(studentMapper = StudentMapperImpl())
+
+    @Test
+    fun `map Room to entity preserves id so an existing room updates in place instead of inserting a duplicate`() {
+        val room = Room(id = 42, floorNumber = 3, roomNumber = 333, bedsCount = 6, students = emptyList())
+
+        val entity = mapper.map(room)
+
+        assertEquals(42, entity.id)
+        assertEquals(3, entity.floorNumber)
+        assertEquals(333, entity.roomNumber)
+        assertEquals(6, entity.bedsCount)
+    }
+}


### PR DESCRIPTION
## Проблема
`RoomMapper.map(Room)` не переносил `id` → `RoomEntity.id` уходил в дефолт `0`. `saveRoomWithStudents` трактует `id == 0` как новую комнату, поэтому каждое сохранение существующей комнаты **вставляло дубль вместо UPDATE**.

Из-за дублей удаление выглядело сломанным: сносишь одну копию — остальные с тем же номером остаются, комната «не исчезает». Само удаление исправно (проверено на устройстве: `count 127 -> 126`, переживает рестарт).

## Фикс
Маппер сохраняет `id` → существующая комната обновляется на месте. Проверено живьём: после сохранения число комнат не растёт, дубль не создаётся. Добавлен регресс-тест на маппер.