### PR TITLE
refactor(upcoming): resolve days-left label in presentation

### DIFF
--- a/shared/feature-upcoming/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/upcoming/presentation/models/UiUpcomingItem.kt
+++ b/shared/feature-upcoming/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/upcoming/presentation/models/UiUpcomingItem.kt
@@ -1,5 +1,8 @@
 package dev.nonoxy.residetrack.feature.upcoming.presentation.models
 
+import dev.icerock.moko.resources.StringResource
+import dev.nonoxy.residetrack.res.MR
+
 data class UiUpcomingItem(
     val roomId: Long,
     val roomNumber: String,
@@ -8,4 +11,14 @@ data class UiUpcomingItem(
     val checkOutDate: String, // ISO-8601
     val daysLeft: Int,
     val bucket: UiUpcomingBucket,
-)
+) {
+
+    // Computed, not constructor args: keeps the model free of moko-resources at construction
+    // so pure mapping logic (and its native unit tests) never trigger MR class init, mirroring
+    // UiUpcomingBucket.title. The overdue/left choice is presentation logic, not UI's to decide.
+    val daysLeftValue: String
+        get() = if (daysLeft < 0) (-daysLeft).toString() else daysLeft.toString()
+
+    val daysLeftLabel: StringResource
+        get() = if (daysLeft < 0) MR.strings.upcoming_days_overdue else MR.strings.upcoming_days_left
+}

--- a/shared/feature-upcoming/presentation/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/upcoming/presentation/mappers/UiUpcomingStateMapperTest.kt
+++ b/shared/feature-upcoming/presentation/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/upcoming/presentation/mappers/UiUpcomingStateMapperTest.kt
@@ -40,6 +40,33 @@ class UiUpcomingStateMapperTest {
         assertEquals("305", item.streamNumber)
         assertEquals("2026-06-01", item.checkOutDate)
         assertEquals(-3, item.daysLeft)
+        assertEquals("3", item.daysLeftValue)
         assertEquals(UiUpcomingBucket.OVERDUE, item.bucket)
     }
+
+    @Test
+    fun daysLeftValueDropsSignForOverdueAndKeepsItForUpcoming() {
+        val state = UpcomingStore.State(
+            items = listOf(
+                upcomingItem(daysLeft = -3, bucket = UpcomingBucket.OVERDUE),
+                upcomingItem(daysLeft = 5, bucket = UpcomingBucket.THIS_WEEK),
+            ),
+        )
+
+        val ui = mapper.map(state)
+
+        assertEquals("3", ui.items[0].daysLeftValue)
+        assertEquals("5", ui.items[1].daysLeftValue)
+    }
+
+    private fun upcomingItem(daysLeft: Int, bucket: UpcomingBucket) = UpcomingItem(
+        roomId = 7,
+        floorNumber = 2,
+        roomNumber = 14,
+        studentId = 10,
+        streamNumber = 305,
+        checkOutDate = LocalDate(2026, 6, 1),
+        daysLeft = daysLeft,
+        bucket = bucket,
+    )
 }

--- a/shared/feature-upcoming/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/upcoming/ui/views/UpcomingListItem.kt
+++ b/shared/feature-upcoming/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/upcoming/ui/views/UpcomingListItem.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import dev.icerock.moko.resources.StringResource
 import dev.icerock.moko.resources.compose.stringResource
 import dev.nonoxy.residetrack.common.ui.theme.ResideTrackTheme
 import dev.nonoxy.residetrack.common.ui.theme.padding_size_10
@@ -63,7 +64,8 @@ internal fun UpcomingListItem(
 
         DaysLeftBadge(
             modifier = Modifier.padding(start = padding_size_10),
-            daysLeft = item.daysLeft,
+            label = item.daysLeftLabel,
+            labelValue = item.daysLeftValue,
             bucket = item.bucket,
         )
     }
@@ -71,15 +73,11 @@ internal fun UpcomingListItem(
 
 @Composable
 private fun DaysLeftBadge(
-    daysLeft: Int,
+    label: StringResource,
+    labelValue: String,
     bucket: UiUpcomingBucket,
     modifier: Modifier = Modifier,
 ) {
-    val text = if (daysLeft < 0) {
-        stringResource(MR.strings.upcoming_days_overdue, (-daysLeft).toString())
-    } else {
-        stringResource(MR.strings.upcoming_days_left, daysLeft.toString())
-    }
     val backgroundColor = when (bucket) {
         UiUpcomingBucket.OVERDUE -> ResideTrackTheme.colors.fillErrorBGSecondary
         UiUpcomingBucket.TODAY_TOMORROW -> ResideTrackTheme.colors.fillWarningBGSecondary
@@ -95,7 +93,7 @@ private fun DaysLeftBadge(
             .clip(ResideTrackTheme.shapes.cornerRadius20)
             .background(backgroundColor)
             .padding(horizontal = padding_size_10, vertical = padding_size_4),
-        text = text,
+        text = stringResource(label, labelValue),
         style = ResideTrackTheme.typography.head5,
         color = textColor,
     )


### PR DESCRIPTION
Выбор строки overdue/left и её значение убраны из `@Composable` в `UiUpcomingItem` (computed `StringResource` + value), UI только резолвит через `stringResource`. Зеркалит существующий паттерн `UiUpcomingBucket.title`, MR-init в native-тестах не триггерит.

Цвета бейджа осознанно остаются в UI: `ResideTrackTheme.colors` composition-scoped, перенос в presentation = хардкод `Color` вне темы.

Покрыто тестом `daysLeftValue` в `UiUpcomingStateMapperTest`.