### PR TITLE
fix(core-rooms): store check-in/out dates as UTC-midnight

### DIFF
--- a/shared/common/src/commonMain/kotlin/dev/nonoxy/residetrack/common/utils/DateTimeExt.kt
+++ b/shared/common/src/commonMain/kotlin/dev/nonoxy/residetrack/common/utils/DateTimeExt.kt
@@ -4,19 +4,26 @@ import kotlin.time.Clock
 import kotlin.time.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
+import kotlinx.datetime.atStartOfDayIn
 import kotlinx.datetime.toLocalDateTime
 
-fun Long.toLocalDate(): LocalDate {
-    return Instant
-        .fromEpochMilliseconds(this)
-        .toLocalDateTime(timeZone = TimeZone.currentSystemDefault())
+// Check-in/out are calendar days without a time component, persisted as UTC-midnight epoch
+// millis. Canonicalizing on UTC keeps the stored day equal to the picked day in every timezone
+// and portable across a backup exported on another device. The Material date picker and
+// RoomEditor already use the same UTC convention.
+fun Long.epochMillisToUtcDate(): LocalDate =
+    Instant.fromEpochMilliseconds(this)
+        .toLocalDateTime(timeZone = TimeZone.UTC)
         .date
-}
 
-fun Instant.toLocalDate(): LocalDate {
-    return this.toLocalDateTime(timeZone = TimeZone.currentSystemDefault())
+fun LocalDate.toUtcStartOfDayMillis(): Long =
+    atStartOfDayIn(TimeZone.UTC).toEpochMilliseconds()
+
+// A real instant resolved to the user's local calendar day — used for "today", never for
+// interpreting a stored calendar date (those go through the UTC helpers above).
+fun Instant.toLocalDate(): LocalDate =
+    toLocalDateTime(timeZone = TimeZone.currentSystemDefault())
         .date
-}
 
 val currentLocalDate: LocalDate
     get() = Clock.System.now().toLocalDate()

--- a/shared/core-rooms/src/commonMain/kotlin/dev/nonoxy/residetrack/core/rooms/data/mappers/StudentMapper.kt
+++ b/shared/core-rooms/src/commonMain/kotlin/dev/nonoxy/residetrack/core/rooms/data/mappers/StudentMapper.kt
@@ -1,13 +1,13 @@
 package dev.nonoxy.residetrack.core.rooms.data.mappers
 
+import dev.nonoxy.residetrack.common.utils.epochMillisToUtcDate
 import dev.nonoxy.residetrack.common.utils.mapper.Mapper
 import dev.nonoxy.residetrack.common.utils.toLocalDate
+import dev.nonoxy.residetrack.common.utils.toUtcStartOfDayMillis
 import dev.nonoxy.residetrack.core.database.entities.StudentEntity
 import dev.nonoxy.residetrack.core.rooms.domain.model.Student
 import dev.nonoxy.residetrack.core.rooms.domain.upcoming.UpcomingCheckouts
 import kotlin.time.Clock
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.atStartOfDayIn
 
 internal interface StudentMapper : Mapper<StudentEntity, Student> {
     fun map(item: Student, roomId: Long): StudentEntity
@@ -18,8 +18,8 @@ internal interface StudentMapper : Mapper<StudentEntity, Student> {
 internal class StudentMapperImpl : StudentMapper {
 
     override fun map(item: StudentEntity): Student {
-        val checkInDate = item.checkInDateEpochMillis.toLocalDate()
-        val checkOutDate = item.checkOutDateEpochMillis.toLocalDate()
+        val checkInDate = item.checkInDateEpochMillis.epochMillisToUtcDate()
+        val checkOutDate = item.checkOutDateEpochMillis.epochMillisToUtcDate()
         val currentDate = Clock.System.now().toLocalDate()
 
         return Student(
@@ -31,14 +31,12 @@ internal class StudentMapperImpl : StudentMapper {
         )
     }
 
-    override fun map(item: Student, roomId: Long): StudentEntity {
-        val tz = TimeZone.currentSystemDefault()
-        return StudentEntity(
+    override fun map(item: Student, roomId: Long): StudentEntity =
+        StudentEntity(
             id = item.id,
             roomId = roomId,
             streamNumber = item.streamNumber,
-            checkInDateEpochMillis = item.checkInDate.atStartOfDayIn(tz).toEpochMilliseconds(),
-            checkOutDateEpochMillis = item.checkOutDate.atStartOfDayIn(tz).toEpochMilliseconds(),
+            checkInDateEpochMillis = item.checkInDate.toUtcStartOfDayMillis(),
+            checkOutDateEpochMillis = item.checkOutDate.toUtcStartOfDayMillis(),
         )
-    }
 }

--- a/shared/core-rooms/src/commonTest/kotlin/dev/nonoxy/residetrack/core/rooms/data/mappers/StudentMapperImplTest.kt
+++ b/shared/core-rooms/src/commonTest/kotlin/dev/nonoxy/residetrack/core/rooms/data/mappers/StudentMapperImplTest.kt
@@ -1,0 +1,61 @@
+package dev.nonoxy.residetrack.core.rooms.data.mappers
+
+import dev.nonoxy.residetrack.core.database.entities.StudentEntity
+import dev.nonoxy.residetrack.core.rooms.domain.model.Student
+import kotlinx.datetime.LocalDate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class StudentMapperImplTest {
+
+    private val mapper = StudentMapperImpl()
+
+    @Test
+    fun `entity millis are read as their UTC calendar day and not the device-local one`() {
+        // 1970-01-01T23:00Z. Read in UTC it stays 1970-01-01; any positive-offset local
+        // timezone (e.g. the CI runner) would roll it into 1970-01-02, pinning read to UTC.
+        val lateInUtcDay = 23L * 60 * 60 * 1000
+        val entity = studentEntity(checkInMillis = lateInUtcDay, checkOutMillis = lateInUtcDay)
+
+        val student = mapper.map(entity)
+
+        assertEquals(LocalDate(1970, 1, 1), student.checkInDate)
+        assertEquals(LocalDate(1970, 1, 1), student.checkOutDate)
+    }
+
+    @Test
+    fun `domain dates are written as UTC-midnight millis and not the device-local ones`() {
+        val student = student(checkIn = LocalDate(1970, 1, 1), checkOut = LocalDate(1970, 1, 1))
+
+        val entity = mapper.map(student, roomId = 1)
+
+        assertEquals(0L, entity.checkInDateEpochMillis)
+        assertEquals(0L, entity.checkOutDateEpochMillis)
+    }
+
+    @Test
+    fun `dates survive an entity to domain to entity round trip in any timezone`() {
+        val student = student(checkIn = LocalDate(2026, 7, 1), checkOut = LocalDate(2026, 7, 10))
+
+        val roundTripped = mapper.map(mapper.map(student, roomId = 1))
+
+        assertEquals(LocalDate(2026, 7, 1), roundTripped.checkInDate)
+        assertEquals(LocalDate(2026, 7, 10), roundTripped.checkOutDate)
+    }
+
+    private fun studentEntity(checkInMillis: Long, checkOutMillis: Long) = StudentEntity(
+        id = 1,
+        roomId = 1,
+        streamNumber = 305,
+        checkInDateEpochMillis = checkInMillis,
+        checkOutDateEpochMillis = checkOutMillis,
+    )
+
+    private fun student(checkIn: LocalDate, checkOut: LocalDate) = Student(
+        id = 1,
+        streamNumber = 305,
+        checkInDate = checkIn,
+        checkOutDate = checkOut,
+        isCheckOutDateNearOrExpired = false,
+    )
+}


### PR DESCRIPTION
`StudentMapper` и `DateTimeExt` писали/читали date-only через `currentSystemDefault()` — даты сдвигались при смене часового пояса устройства и при переносе бэкапа между устройствами (millis были tz-зависимы).

Канонизируем date-only на UTC, как уже делают Material date-picker и `RoomEditorExecutor`. Неоднозначный `Long.toLocalDate()` заменён на явные `epochMillisToUtcDate()` / `toUtcStartOfDayMillis()`; «сегодня» (`Instant.toLocalDate`/`currentLocalDate`) остаётся локальным.

Новый `StudentMapperImplTest`: read/write UTC-anchor + round-trip.

⚠️ Существующие строки студентов писались в local-tz — после мержа прочитаются как UTC (сдвиг на день у ранее введённых). Сид без студентов, прод-юзеров нет.