### PR TITLE
chore: drop AI-tool entries from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 *.iml
 .kotlin
 .gradle
-.claude/scheduled_tasks.lock
 **/build/
 xcuserdata
 !src/**/build/
@@ -18,6 +17,3 @@ captures
 !*.xcworkspace/contents.xcworkspacedata
 **/xcshareddata/WorkspaceSettings.xcsettings
 app_db.db
-
-# Visual brainstorming companion
-.superpowers/


### PR DESCRIPTION
Убраны строки AI-тулинга из `.gitignore` (`.claude/scheduled_tasks.lock`, `.superpowers/`) — в репозитории не место следам AI-инструментов.