### PR TITLE
feat(room-editor): scaffold layout, UX fixes, and beds-count cap

### DIFF
--- a/shared/common-resources/src/commonMain/moko-resources/base/strings.xml
+++ b/shared/common-resources/src/commonMain/moko-resources/base/strings.xml
@@ -75,6 +75,7 @@
     <string name="students_total_count">Всего слушателей: %1$d</string>
     <string name="students_saved_successfully">Студенты успешно сохранены</string>
 
+    <string name="error_student_fields_required">Заполните все поля для каждого слушателя</string>
     <string name="error_stream_number_required">Номер потока обязателен</string>
     <string name="error_stream_number_invalid">Номер потока должен быть числом</string>
     <string name="error_check_in_date_required">Дата заселения обязательна</string>

--- a/shared/feature-room-editor/api/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/api/store/RoomEditorErrorKind.kt
+++ b/shared/feature-room-editor/api/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/api/store/RoomEditorErrorKind.kt
@@ -5,6 +5,7 @@ sealed interface RoomEditorErrorKind {
     data object FailedToSaveStudents : RoomEditorErrorKind
     data object RoomNotFound : RoomEditorErrorKind
     data object DraftRoomNotFound : RoomEditorErrorKind
+    data object IncompleteStudentData : RoomEditorErrorKind
     data object StreamNumberInvalid : RoomEditorErrorKind
     data object InvalidDateRange : RoomEditorErrorKind
     data object InvalidDateFormat : RoomEditorErrorKind

--- a/shared/feature-room-editor/api/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/api/store/RoomEditorStore.kt
+++ b/shared/feature-room-editor/api/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/api/store/RoomEditorStore.kt
@@ -14,7 +14,10 @@ interface RoomEditorStore : Store<Intent, State, Label> {
         val errorKind: RoomEditorErrorKind? = null,
         val room: Room? = null,
         val editableStudents: List<EditableStudent> = emptyList(),
+        val initialStudentCount: Int = 0,
         val isDirty: Boolean = false,
+        val isSaveEnabled: Boolean = false,
+        val isAddStudentEnabled: Boolean = true,
         val showDiscardConfirm: Boolean = false,
         val openDatePicker: OpenPicker? = null,
         val showRoomParams: Boolean = false,
@@ -22,6 +25,7 @@ interface RoomEditorStore : Store<Intent, State, Label> {
         val showDeleteConfirm: Boolean = false,
         val removingStudentId: String? = null,
     ) {
+
         data class EditableStudent(
             val id: String,
             val studentId: Long?,

--- a/shared/feature-room-editor/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/impl/domain/RoomEditorExecutor.kt
+++ b/shared/feature-room-editor/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/impl/domain/RoomEditorExecutor.kt
@@ -146,6 +146,8 @@ internal class RoomEditorExecutor(
     }
 
     private fun handleAddStudent() {
+        val currentState = state()
+        if (currentState.editableStudents.size >= (currentState.room?.bedsCount ?: Int.MAX_VALUE)) return
         val newStudent = State.EditableStudent(
             id = Uuid.random().toString(),
             studentId = null,
@@ -248,7 +250,8 @@ internal class RoomEditorExecutor(
                 editable.checkInDate.isBlank() ||
                 editable.checkOutDate.isBlank()
             ) {
-                continue
+                publish(Label.ShowError(kind = RoomEditorErrorKind.IncompleteStudentData))
+                return null
             }
 
             val streamNumber = editable.streamNumber.toIntOrNull()

--- a/shared/feature-room-editor/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/impl/domain/RoomEditorReducer.kt
+++ b/shared/feature-room-editor/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/impl/domain/RoomEditorReducer.kt
@@ -30,7 +30,10 @@ internal class RoomEditorReducer : Reducer<State, Message> {
             errorKind = null,
             room = msg.room,
             editableStudents = msg.editableStudents,
+            initialStudentCount = msg.editableStudents.size,
             isDirty = false,
+            isSaveEnabled = false,
+            isAddStudentEnabled = msg.editableStudents.size < msg.room.bedsCount,
             showDiscardConfirm = false,
             removingStudentId = null,
         )
@@ -38,6 +41,8 @@ internal class RoomEditorReducer : Reducer<State, Message> {
         is Message.SetEditableStudents -> copy(
             editableStudents = msg.editableStudents,
             isDirty = true,
+            isSaveEnabled = msg.editableStudents.isNotEmpty() || initialStudentCount > 0,
+            isAddStudentEnabled = msg.editableStudents.size < (room?.bedsCount ?: Int.MAX_VALUE),
         )
 
         is Message.SetShowDiscardConfirm -> copy(
@@ -51,7 +56,10 @@ internal class RoomEditorReducer : Reducer<State, Message> {
         is Message.SetShowRoomParams -> copy(showRoomParams = msg.show)
         is Message.SetRoomParams -> copy(roomParams = msg.params)
         is Message.SetShowDeleteConfirm -> copy(showDeleteConfirm = msg.show)
-        is Message.SetRoom -> copy(room = msg.room)
+        is Message.SetRoom -> copy(
+            room = msg.room,
+            isAddStudentEnabled = editableStudents.size < msg.room.bedsCount,
+        )
         is Message.SetRemovingStudentId -> copy(removingStudentId = msg.studentId)
     }
 }

--- a/shared/feature-room-editor/impl/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/room_editor/impl/domain/RoomEditorExecutorTest.kt
+++ b/shared/feature-room-editor/impl/src/commonTest/kotlin/dev/nonoxy/residetrack/feature/room_editor/impl/domain/RoomEditorExecutorTest.kt
@@ -191,6 +191,22 @@ class RoomEditorExecutorTest {
     }
 
     @Test
+    fun `save with blank student fields is rejected`() = runTest {
+        val repository = FakeRoomsRepository(rooms = listOf(room(id = 1)))
+        val store = createStore(repository, RoomEditorMode.ExistingRoom(roomId = "1"))
+        val labels = labelsOf(store)
+
+        store.accept(Intent.OnAddStudent)
+        store.accept(Intent.OnSaveAndClose)
+        advanceUntilIdle()
+
+        assertEquals(0, repository.saveRoomCallCount)
+        assertTrue(labels.contains(Label.ShowError(RoomEditorErrorKind.IncompleteStudentData)))
+
+        store.dispose()
+    }
+
+    @Test
     fun `save with duplicate stream numbers is rejected`() = runTest {
         val repository = FakeRoomsRepository(
             rooms = listOf(

--- a/shared/feature-room-editor/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/presentation/mappers/UiRoomEditorLabelMapper.kt
+++ b/shared/feature-room-editor/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/presentation/mappers/UiRoomEditorLabelMapper.kt
@@ -30,6 +30,8 @@ internal class UiRoomEditorLabelMapperImpl(
         )
         RoomEditorErrorKind.RoomNotFound -> stringConverter.convert(MR.strings.error_room_not_found)
         RoomEditorErrorKind.DraftRoomNotFound -> stringConverter.convert(MR.strings.error_draft_room_not_found)
+        RoomEditorErrorKind.IncompleteStudentData ->
+            stringConverter.convert(MR.strings.error_student_fields_required)
         RoomEditorErrorKind.StreamNumberInvalid -> stringConverter.convert(MR.strings.error_stream_number_invalid)
         RoomEditorErrorKind.InvalidDateRange -> stringConverter.convert(MR.strings.error_invalid_date_range)
         RoomEditorErrorKind.InvalidDateFormat -> stringConverter.convert(MR.strings.error_invalid_date_format)

--- a/shared/feature-room-editor/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/presentation/mappers/UiRoomEditorStateMapper.kt
+++ b/shared/feature-room-editor/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/presentation/mappers/UiRoomEditorStateMapper.kt
@@ -22,6 +22,8 @@ internal class UiRoomEditorStateMapperImpl(
         isError = item.isError,
         errorKind = item.errorKind,
         room = item.room?.let(uiRoomMapper::map),
+        isSaveEnabled = item.isSaveEnabled,
+        isAddStudentEnabled = item.isAddStudentEnabled,
         editableStudents = item.editableStudents.map { st ->
             UiEditableStudent(
                 id = st.id,

--- a/shared/feature-room-editor/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/presentation/models/UiRoomEditorState.kt
+++ b/shared/feature-room-editor/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/presentation/models/UiRoomEditorState.kt
@@ -10,6 +10,8 @@ data class UiRoomEditorState(
     val errorKind: RoomEditorErrorKind? = null,
     val room: UiRoom? = null,
     val editableStudents: ImmutableList<UiEditableStudent> = persistentListOf(),
+    val isSaveEnabled: Boolean = false,
+    val isAddStudentEnabled: Boolean = true,
     val isDirty: Boolean = false,
     val showDiscardConfirm: Boolean = false,
     val openDatePicker: UiOpenDatePicker? = null,

--- a/shared/feature-room-editor/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/ui/RoomEditorScreen.kt
+++ b/shared/feature-room-editor/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/ui/RoomEditorScreen.kt
@@ -1,9 +1,9 @@
 package dev.nonoxy.residetrack.feature.room_editor.ui
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
@@ -12,11 +12,11 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.nonoxy.residetrack.feature.room_editor.presentation.RoomEditorViewModel
 import dev.nonoxy.residetrack.feature.room_editor.presentation.models.UiRoomEditorLabel
+import dev.nonoxy.residetrack.feature.room_editor.ui.views.EditorActionButtons
 import dev.nonoxy.residetrack.feature.room_editor.ui.views.RoomEditorContent
 import dev.nonoxy.residetrack.feature.room_editor.ui.views.DeleteRoomDialog
 import dev.nonoxy.residetrack.feature.room_editor.ui.views.RemoveStudentDialog
@@ -103,18 +103,39 @@ internal fun RoomEditorScreen(
         }
     }
 
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(ResideTrackTheme.colors.background),
-    ) {
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        containerColor = ResideTrackTheme.colors.background,
+        contentWindowInsets = WindowInsets(0, 0, 0, 0),
+        bottomBar = {
+            EditorActionButtons(
+                onCloseClick = viewModel::onClose,
+                onSaveAndClose = viewModel::onSaveAndClose,
+                isSaveEnabled = state.isSaveEnabled,
+                modifier = Modifier.imePadding(),
+            )
+        },
+        snackbarHost = {
+            SnackbarHost(
+                hostState = snackbarHostState,
+                snackbar = { snackbarData ->
+                    when (currentSnackbarType) {
+                        SnackbarType.ERROR -> ResideTrackErrorSnackbar(snackbarData = snackbarData)
+                        SnackbarType.INFO -> ResideTrackSnackbar(snackbarData = snackbarData)
+                        else -> Unit
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
         RoomEditorContent(
             modifier = Modifier.fillMaxSize(),
+            bottomPadding = innerPadding.calculateBottomPadding(),
             state = state,
             onRetryClick = viewModel::onRetryLoadStudents,
-            onCloseClick = viewModel::onClose,
             onEditRoomParamsClick = viewModel::onEditRoomParamsClick,
             onAddStudent = viewModel::onAddStudent,
+            isAddStudentEnabled = state.isAddStudentEnabled,
             onRemoveStudent = viewModel::onRemoveStudent,
             onStreamNumberChange = viewModel::onStreamNumberChange,
             onCheckInDateChange = viewModel::onCheckInDateChange,
@@ -123,21 +144,6 @@ internal fun RoomEditorScreen(
             onCheckOutDateMillisChange = viewModel::onCheckOutDateMillisChange,
             onOpenPicker = viewModel::onDatePickerOpen,
             onDismissPicker = viewModel::onDatePickerDismiss,
-            onSaveAndClose = viewModel::onSaveAndClose,
-        )
-
-        SnackbarHost(
-            hostState = snackbarHostState,
-            modifier = Modifier
-                .align(Alignment.BottomCenter)
-                .navigationBarsPadding(),
-            snackbar = { snackbarData ->
-                when (currentSnackbarType) {
-                    SnackbarType.ERROR -> ResideTrackErrorSnackbar(snackbarData = snackbarData)
-                    SnackbarType.INFO -> ResideTrackSnackbar(snackbarData = snackbarData)
-                    else -> Unit
-                }
-            },
         )
     }
 }

--- a/shared/feature-room-editor/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/ui/views/EditorActionButtons.kt
+++ b/shared/feature-room-editor/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/ui/views/EditorActionButtons.kt
@@ -19,16 +19,15 @@ import dev.nonoxy.residetrack.common.ui.common.button.ResideTrackButton
 import dev.nonoxy.residetrack.common.ui.theme.ResideTrackTheme
 import dev.nonoxy.residetrack.common.ui.theme.padding_size_12
 import dev.nonoxy.residetrack.common.ui.theme.padding_size_16
-import dev.nonoxy.residetrack.common.ui.theme.padding_size_24
+import dev.nonoxy.residetrack.common.ui.theme.padding_size_8
 import dev.nonoxy.residetrack.common.ui.theme.size_1
 import dev.nonoxy.residetrack.res.MR
 
-/** Floating Cancel/Save row. Sits over the scrolling list; a top gradient scrim keeps the
- *  buttons legible as content scrolls under them. */
 @Composable
 internal fun EditorActionButtons(
     onCloseClick: () -> Unit,
     onSaveAndClose: () -> Unit,
+    isSaveEnabled: Boolean,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -44,7 +43,7 @@ internal fun EditorActionButtons(
             )
             .navigationBarsPadding()
             .padding(horizontal = padding_size_16)
-            .padding(top = padding_size_24, bottom = padding_size_16),
+            .padding(vertical = padding_size_8),
     ) {
         Row(horizontalArrangement = Arrangement.spacedBy(padding_size_12)) {
             OutlinedButton(
@@ -63,6 +62,7 @@ internal fun EditorActionButtons(
 
             ResideTrackButton(
                 onClick = onSaveAndClose,
+                enabled = isSaveEnabled,
                 modifier = Modifier.weight(1f),
             ) {
                 Text(

--- a/shared/feature-room-editor/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/ui/views/EmptyStudentsState.kt
+++ b/shared/feature-room-editor/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/ui/views/EmptyStudentsState.kt
@@ -11,10 +11,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
+import dev.icerock.moko.resources.compose.stringResource
 import dev.nonoxy.residetrack.common.ui.theme.ResideTrackTheme
 import dev.nonoxy.residetrack.common.ui.theme.padding_size_32
 import dev.nonoxy.residetrack.common.ui.theme.padding_size_8
-import dev.icerock.moko.resources.compose.stringResource
 import dev.nonoxy.residetrack.res.MR
 
 @Composable

--- a/shared/feature-room-editor/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/ui/views/RoomEditorContent.kt
+++ b/shared/feature-room-editor/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/ui/views/RoomEditorContent.kt
@@ -1,12 +1,12 @@
 package dev.nonoxy.residetrack.feature.room_editor.ui.views
 
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import dev.nonoxy.residetrack.feature.room_editor.presentation.models.UiDateField
 import dev.nonoxy.residetrack.feature.room_editor.presentation.models.UiRoomEditorState
@@ -17,9 +17,9 @@ import dev.nonoxy.residetrack.common.ui.theme.padding_size_8
 internal fun RoomEditorContent(
     state: UiRoomEditorState,
     onRetryClick: () -> Unit,
-    onCloseClick: () -> Unit,
     onEditRoomParamsClick: () -> Unit,
     onAddStudent: () -> Unit,
+    isAddStudentEnabled: Boolean,
     onRemoveStudent: (String) -> Unit,
     onStreamNumberChange: (String, String) -> Unit,
     onCheckInDateChange: (String, String) -> Unit,
@@ -28,7 +28,7 @@ internal fun RoomEditorContent(
     onCheckOutDateMillisChange: (String, Long) -> Unit,
     onOpenPicker: (String, UiDateField) -> Unit,
     onDismissPicker: () -> Unit,
-    onSaveAndClose: () -> Unit,
+    bottomPadding: Dp = 0.dp,
     modifier: Modifier = Modifier,
 ) {
     ShowStateData(
@@ -50,28 +50,22 @@ internal fun RoomEditorContent(
                 )
             }
 
-            Box(modifier = Modifier.weight(1f).fillMaxSize()) {
-                RoomEditorList(
-                    students = currentState.editableStudents,
-                    openDatePicker = currentState.openDatePicker,
-                    onAddStudent = onAddStudent,
-                    onRemoveStudent = onRemoveStudent,
-                    onStreamNumberChange = onStreamNumberChange,
-                    onCheckInDateChange = onCheckInDateChange,
-                    onCheckOutDateChange = onCheckOutDateChange,
-                    onCheckInDateMillisChange = onCheckInDateMillisChange,
-                    onCheckOutDateMillisChange = onCheckOutDateMillisChange,
-                    onOpenPicker = onOpenPicker,
-                    onDismissPicker = onDismissPicker,
-                    modifier = Modifier.fillMaxSize(),
-                )
-
-                EditorActionButtons(
-                    onCloseClick = onCloseClick,
-                    onSaveAndClose = onSaveAndClose,
-                    modifier = Modifier.align(Alignment.BottomCenter),
-                )
-            }
+            RoomEditorList(
+                students = currentState.editableStudents,
+                openDatePicker = currentState.openDatePicker,
+                onAddStudent = onAddStudent,
+                isAddStudentEnabled = isAddStudentEnabled,
+                bottomPadding = bottomPadding,
+                onRemoveStudent = onRemoveStudent,
+                onStreamNumberChange = onStreamNumberChange,
+                onCheckInDateChange = onCheckInDateChange,
+                onCheckOutDateChange = onCheckOutDateChange,
+                onCheckInDateMillisChange = onCheckInDateMillisChange,
+                onCheckOutDateMillisChange = onCheckOutDateMillisChange,
+                onOpenPicker = onOpenPicker,
+                onDismissPicker = onDismissPicker,
+                modifier = Modifier.weight(1f).fillMaxSize(),
+            )
         }
     }
 }

--- a/shared/feature-room-editor/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/ui/views/RoomEditorList.kt
+++ b/shared/feature-room-editor/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/ui/views/RoomEditorList.kt
@@ -3,6 +3,8 @@ package dev.nonoxy.residetrack.feature.room_editor.ui.views
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -24,7 +26,6 @@ import dev.nonoxy.residetrack.common.ui.theme.ResideTrackTheme
 import dev.nonoxy.residetrack.common.ui.theme.padding_size_12
 import dev.nonoxy.residetrack.common.ui.theme.padding_size_16
 import dev.nonoxy.residetrack.common.ui.theme.padding_size_8
-import dev.nonoxy.residetrack.common.ui.theme.padding_size_96
 import dev.nonoxy.residetrack.common.ui.theme.size_1
 import kotlinx.collections.immutable.ImmutableList
 import dev.icerock.moko.resources.compose.stringResource
@@ -35,6 +36,8 @@ internal fun RoomEditorList(
     students: ImmutableList<UiEditableStudent>,
     openDatePicker: UiOpenDatePicker?,
     onAddStudent: () -> Unit,
+    isAddStudentEnabled: Boolean,
+    bottomPadding: Dp = 0.dp,
     onRemoveStudent: (String) -> Unit,
     onStreamNumberChange: (String, String) -> Unit,
     onCheckInDateChange: (String, String) -> Unit,
@@ -51,7 +54,7 @@ internal fun RoomEditorList(
             start = padding_size_16,
             end = padding_size_16,
             top = padding_size_16,
-            bottom = padding_size_96,
+            bottom = padding_size_16 + bottomPadding,
         ),
         verticalArrangement = Arrangement.spacedBy(padding_size_12),
     ) {
@@ -98,27 +101,29 @@ internal fun RoomEditorList(
             )
         }
 
-        item {
-            OutlinedButton(
-                onClick = onAddStudent,
-                modifier = Modifier.fillMaxWidth(),
-                border = BorderStroke(
-                    width = size_1,
-                    color = ResideTrackTheme.colors.borderDefault,
-                ),
-                colors = ButtonDefaults.outlinedButtonColors(
-                    contentColor = ResideTrackTheme.colors.textPrimary,
-                ),
-            ) {
-                Icon(
-                    imageVector = Icons.Default.Add,
-                    contentDescription = stringResource(MR.strings.add_student),
-                )
-                Spacer(modifier = Modifier.width(padding_size_8))
-                Text(
-                    text = stringResource(MR.strings.add_student),
-                    style = ResideTrackTheme.typography.paragraph,
-                )
+        if (isAddStudentEnabled) {
+            item {
+                OutlinedButton(
+                    onClick = onAddStudent,
+                    modifier = Modifier.fillMaxWidth(),
+                    border = BorderStroke(
+                        width = size_1,
+                        color = ResideTrackTheme.colors.borderDefault,
+                    ),
+                    colors = ButtonDefaults.outlinedButtonColors(
+                        contentColor = ResideTrackTheme.colors.textPrimary,
+                    ),
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Add,
+                        contentDescription = stringResource(MR.strings.add_student),
+                    )
+                    Spacer(modifier = Modifier.width(padding_size_8))
+                    Text(
+                        text = stringResource(MR.strings.add_student),
+                        style = ResideTrackTheme.typography.paragraph,
+                    )
+                }
             }
         }
 

--- a/shared/feature-room-editor/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/ui/views/StudentCardContent.kt
+++ b/shared/feature-room-editor/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/ui/views/StudentCardContent.kt
@@ -9,16 +9,24 @@ import androidx.compose.material3.SelectableDates
 import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.key
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.input.KeyboardType
 import dev.nonoxy.residetrack.common.ui.common.datepicker.ResideTrackDatePicker
 import dev.nonoxy.residetrack.common.ui.common.textfield.ResideTrackTextField
 import dev.nonoxy.residetrack.common.ui.theme.padding_size_8
+import dev.nonoxy.residetrack.common.utils.currentLocalDate
 import dev.nonoxy.residetrack.feature.room_editor.presentation.models.UiDateField
 import dev.icerock.moko.resources.compose.stringResource
 import dev.nonoxy.residetrack.res.MR
+import kotlinx.datetime.DatePeriod
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.format.FormatStringsInDatetimeFormats
+import kotlinx.datetime.format.byUnicodePattern
+import kotlinx.datetime.plus
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, FormatStringsInDatetimeFormats::class)
 @Composable
 internal fun StudentCardContent(
     streamNumber: String,
@@ -51,6 +59,13 @@ internal fun StudentCardContent(
         )
     }
 
+    val focusManager = LocalFocusManager.current
+    val dateHintFormat = remember { LocalDate.Format { byUnicodePattern("dd.MM.yyyy") } }
+    val checkInPlaceholder = remember { dateHintFormat.format(currentLocalDate) }
+    val checkOutPlaceholder = remember {
+        dateHintFormat.format(currentLocalDate.plus(DatePeriod(months = 6)))
+    }
+
     Column(
         modifier = modifier.fillMaxWidth()
     ) {
@@ -68,10 +83,15 @@ internal fun StudentCardContent(
         ResideTrackDatePicker(
             showDatePicker = openField == UiDateField.CHECK_IN,
             onShowDatePickerStateChange = { show ->
-                if (show) onOpenPicker(UiDateField.CHECK_IN) else onDismissPicker()
+                if (show) {
+                    focusManager.clearFocus()
+                    onOpenPicker(UiDateField.CHECK_IN)
+                } else {
+                    onDismissPicker()
+                }
             },
             value = checkInDate,
-            placeholder = stringResource(MR.strings.check_in_date_placeholder),
+            placeholder = checkInPlaceholder,
             datePickerState = checkInPickerState,
             onDateSelect = onCheckInDateMillisChange,
             saveButtonText = stringResource(MR.strings.save),
@@ -84,10 +104,15 @@ internal fun StudentCardContent(
         ResideTrackDatePicker(
             showDatePicker = openField == UiDateField.CHECK_OUT,
             onShowDatePickerStateChange = { show ->
-                if (show) onOpenPicker(UiDateField.CHECK_OUT) else onDismissPicker()
+                if (show) {
+                    focusManager.clearFocus()
+                    onOpenPicker(UiDateField.CHECK_OUT)
+                } else {
+                    onDismissPicker()
+                }
             },
             value = checkOutDate,
-            placeholder = stringResource(MR.strings.check_out_date_placeholder),
+            placeholder = checkOutPlaceholder,
             datePickerState = checkOutPickerState,
             onDateSelect = onCheckOutDateMillisChange,
             saveButtonText = stringResource(MR.strings.save),


### PR DESCRIPTION
## Changes

- Migrate `RoomEditorScreen` from `Box` overlay to `Scaffold` with `bottomBar` and `snackbarHost`
- Dynamic date placeholders computed at compose-time in `StudentCardContent`
- Keyboard dismissed automatically when date picker opens
- Blank student fields on save now surface `IncompleteStudentData` error (previously silently skipped)
- `initialStudentCount` tracks loaded state so `isDirty` and save button work correctly on empty rooms
- `isAddStudentEnabled` enforced in both domain (executor guard) and UI (+ button hidden at capacity)
- `bottomBar` gradient fixed: list extends under buttons via `contentPadding.bottom`, fade effect now visible