### PR TITLE
fix(backup): iOS modal fix, stale lambdas, Dispatchers.IO; iOS flavor setup

### DIFF
--- a/android/app/src/dev/res/values/strings.xml
+++ b/android/app/src/dev/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">[DEV] Reside Track</string>
+</resources>

--- a/iosApp/Configuration/Config.xcconfig
+++ b/iosApp/Configuration/Config.xcconfig
@@ -1,3 +1,1 @@
 TEAM_ID=
-BUNDLE_ID=dev.nonoxy.residetrack.ResideTrack
-APP_NAME=Reside Track

--- a/iosApp/Configuration/Dev.xcconfig
+++ b/iosApp/Configuration/Dev.xcconfig
@@ -1,0 +1,3 @@
+#include "Config.xcconfig"
+APP_NAME = [DEV] Reside Track
+BUNDLE_ID = dev.nonoxy.residetrack.ResideTrack.dev

--- a/iosApp/Configuration/Prod.xcconfig
+++ b/iosApp/Configuration/Prod.xcconfig
@@ -1,0 +1,3 @@
+#include "Config.xcconfig"
+APP_NAME = Reside Track
+BUNDLE_ID = dev.nonoxy.residetrack.ResideTrack

--- a/iosApp/ResideTrack.xcodeproj/project.pbxproj
+++ b/iosApp/ResideTrack.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 		7555FF82242A565900829871 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		7555FF8C242A565B00829871 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		AB3632DC29227652001CCB65 /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
+		AB3632DD29227652001CCB65 /* Dev.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Dev.xcconfig; sourceTree = "<group>"; };
+		AB3632DE29227652001CCB65 /* Prod.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Prod.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -83,6 +85,8 @@
 			isa = PBXGroup;
 			children = (
 				AB3632DC29227652001CCB65 /* Config.xcconfig */,
+				AB3632DD29227652001CCB65 /* Dev.xcconfig */,
+				AB3632DE29227652001CCB65 /* Prod.xcconfig */,
 			);
 			path = Configuration;
 			sourceTree = "<group>";
@@ -90,11 +94,12 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		7555FF7A242A565900829871 /* iosApp */ = {
+		7555FF7A242A565900829871 /* ResideTrack */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 7555FFA5242A565B00829871 /* Build configuration list for PBXNativeTarget "iosApp" */;
+			buildConfigurationList = 7555FFA5242A565B00829871 /* Build configuration list for PBXNativeTarget "ResideTrack" */;
 			buildPhases = (
 				F36B1CEB2AD83DDC00CB74D5 /* Compile Kotlin Framework */,
+				A0B1C2D3E4F5000100000001 /* Copy MOKO Resources */,
 				7555FF77242A565900829871 /* Sources */,
 				B92378962B6B1156000C7307 /* Frameworks */,
 				7555FF79242A565900829871 /* Resources */,
@@ -103,10 +108,10 @@
 			);
 			dependencies = (
 			);
-			name = iosApp;
+			name = ResideTrack;
 			packageProductDependencies = (
 			);
-			productName = iosApp;
+			productName = ResideTrack;
 			productReference = 7555FF7B242A565900829871 /* Reside Track.app */;
 			productType = "com.apple.product-type.application";
 		};
@@ -126,7 +131,7 @@
 					};
 				};
 			};
-			buildConfigurationList = 7555FF76242A565900829871 /* Build configuration list for PBXProject "iosApp" */;
+			buildConfigurationList = 7555FF76242A565900829871 /* Build configuration list for PBXProject "ResideTrack" */;
 			compatibilityVersion = "Xcode 14.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
@@ -141,7 +146,7 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				7555FF7A242A565900829871 /* iosApp */,
+				7555FF7A242A565900829871 /* ResideTrack */,
 			);
 		};
 /* End PBXProject section */
@@ -159,6 +164,24 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		A0B1C2D3E4F5000100000001 /* Copy MOKO Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Copy MOKO Resources";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"$SRCROOT/../gradlew\" -p \"$SRCROOT/../\" :shared:main:copyFrameworkResourcesToApp \\\n    -Pmoko.resources.PLATFORM_NAME=\"$PLATFORM_NAME\" \\\n    -Pmoko.resources.CONFIGURATION=\"${KOTLIN_FRAMEWORK_BUILD_TYPE:-$CONFIGURATION}\" \\\n    -Pmoko.resources.ARCHS=\"$ARCHS\" \\\n    -Pmoko.resources.BUILT_PRODUCTS_DIR=\"$BUILT_PRODUCTS_DIR\" \\\n    -Pmoko.resources.CONTENTS_FOLDER_PATH=\"$CONTENTS_FOLDER_PATH\" \n";
+		};
 		F36B1CEB2AD83DDC00CB74D5 /* Compile Kotlin Framework */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -192,9 +215,9 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
-		7555FFA3242A565B00829871 /* Debug */ = {
+		AB3632DF29227652001CCB65 /* Dev Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = AB3632DC29227652001CCB65 /* Config.xcconfig */;
+			baseConfigurationReference = AB3632DD29227652001CCB65 /* Dev.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -245,7 +268,8 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				KOTLIN_FRAMEWORK_BUILD_TYPE = Debug;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -253,11 +277,11 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
-			name = Debug;
+			name = "Dev Debug";
 		};
-		7555FFA4242A565B00829871 /* Release */ = {
+		AB3632E029227652001CCB65 /* Dev Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = AB3632DC29227652001CCB65 /* Config.xcconfig */;
+			baseConfigurationReference = AB3632DD29227652001CCB65 /* Dev.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -302,7 +326,8 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				KOTLIN_FRAMEWORK_BUILD_TYPE = Release;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
@@ -310,9 +335,131 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				VALIDATE_PRODUCT = YES;
 			};
-			name = Release;
+			name = "Dev Release";
 		};
-		7555FFA6242A565B00829871 /* Debug */ = {
+		AB3632E129227652001CCB65 /* Prod Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = AB3632DE29227652001CCB65 /* Prod.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				KOTLIN_FRAMEWORK_BUILD_TYPE = Debug;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = "Prod Debug";
+		};
+		AB3632E229227652001CCB65 /* Prod Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = AB3632DE29227652001CCB65 /* Prod.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				KOTLIN_FRAMEWORK_BUILD_TYPE = Release;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = "Prod Release";
+		};
+		AB3632E329227652001CCB65 /* Dev Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -323,10 +470,10 @@
 				ENABLE_PREVIEWS = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(SRCROOT)/../shared/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)\n$(SRCROOT)/../shared/main/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)",
+					"$(SRCROOT)/../shared/build/xcode-frameworks/$(KOTLIN_FRAMEWORK_BUILD_TYPE)/$(SDK_NAME)\n$(SRCROOT)/../shared/main/build/xcode-frameworks/$(KOTLIN_FRAMEWORK_BUILD_TYPE)/$(SDK_NAME)",
 				);
 				INFOPLIST_FILE = iosApp/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -337,9 +484,9 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
-			name = Debug;
+			name = "Dev Debug";
 		};
-		7555FFA7242A565B00829871 /* Release */ = {
+		AB3632E429227652001CCB65 /* Dev Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -350,10 +497,10 @@
 				ENABLE_PREVIEWS = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(SRCROOT)/../shared/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)\n$(SRCROOT)/../shared/main/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)",
+					"$(SRCROOT)/../shared/build/xcode-frameworks/$(KOTLIN_FRAMEWORK_BUILD_TYPE)/$(SDK_NAME)\n$(SRCROOT)/../shared/main/build/xcode-frameworks/$(KOTLIN_FRAMEWORK_BUILD_TYPE)/$(SDK_NAME)",
 				);
 				INFOPLIST_FILE = iosApp/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -364,28 +511,86 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
-			name = Release;
+			name = "Dev Release";
+		};
+		AB3632E529227652001CCB65 /* Prod Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
+				DEVELOPMENT_TEAM = "${TEAM_ID}";
+				ENABLE_PREVIEWS = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../shared/build/xcode-frameworks/$(KOTLIN_FRAMEWORK_BUILD_TYPE)/$(SDK_NAME)\n$(SRCROOT)/../shared/main/build/xcode-frameworks/$(KOTLIN_FRAMEWORK_BUILD_TYPE)/$(SDK_NAME)",
+				);
+				INFOPLIST_FILE = iosApp/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "${BUNDLE_ID}${TEAM_ID}";
+				PRODUCT_NAME = "${APP_NAME}";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Prod Debug";
+		};
+		AB3632E629227652001CCB65 /* Prod Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
+				DEVELOPMENT_TEAM = "${TEAM_ID}";
+				ENABLE_PREVIEWS = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../shared/build/xcode-frameworks/$(KOTLIN_FRAMEWORK_BUILD_TYPE)/$(SDK_NAME)\n$(SRCROOT)/../shared/main/build/xcode-frameworks/$(KOTLIN_FRAMEWORK_BUILD_TYPE)/$(SDK_NAME)",
+				);
+				INFOPLIST_FILE = iosApp/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "${BUNDLE_ID}${TEAM_ID}";
+				PRODUCT_NAME = "${APP_NAME}";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Prod Release";
 		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		7555FF76242A565900829871 /* Build configuration list for PBXProject "iosApp" */ = {
+		7555FF76242A565900829871 /* Build configuration list for PBXProject "ResideTrack" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				7555FFA3242A565B00829871 /* Debug */,
-				7555FFA4242A565B00829871 /* Release */,
+				AB3632DF29227652001CCB65 /* Dev Debug */,
+				AB3632E029227652001CCB65 /* Dev Release */,
+				AB3632E129227652001CCB65 /* Prod Debug */,
+				AB3632E229227652001CCB65 /* Prod Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = "Prod Release";
 		};
-		7555FFA5242A565B00829871 /* Build configuration list for PBXNativeTarget "iosApp" */ = {
+		7555FFA5242A565B00829871 /* Build configuration list for PBXNativeTarget "ResideTrack" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				7555FFA6242A565B00829871 /* Debug */,
-				7555FFA7242A565B00829871 /* Release */,
+				AB3632E329227652001CCB65 /* Dev Debug */,
+				AB3632E429227652001CCB65 /* Dev Release */,
+				AB3632E529227652001CCB65 /* Prod Debug */,
+				AB3632E629227652001CCB65 /* Prod Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = "Prod Release";
 		};
 /* End XCConfigurationList section */
 	};

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -13,6 +13,6 @@ struct ComposeView: UIViewControllerRepresentable {
 struct ContentView: View {
     var body: some View {
         ComposeView()
-            .ignoresSafeArea(.keyboard) // Compose has own keyboard handler
+            .ignoresSafeArea(.all) // Compose has own insets handler
     }
 }

--- a/shared/feature-rooms/ui/src/androidMain/kotlin/dev/nonoxy/residetrack/feature/rooms/ui/BackupFilePicker.android.kt
+++ b/shared/feature-rooms/ui/src/androidMain/kotlin/dev/nonoxy/residetrack/feature/rooms/ui/BackupFilePicker.android.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
@@ -21,6 +22,7 @@ internal actual fun rememberBackupFilePicker(
 ): BackupFilePicker {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
+    val currentOnExportCompleted by rememberUpdatedState(onExportCompleted)
     // rememberSaveable so a destination chosen after process death still finds its JSON to write.
     var pendingJson by rememberSaveable { mutableStateOf<String?>(null) }
 
@@ -65,7 +67,7 @@ internal actual fun rememberBackupFilePicker(
                 createLauncher.launch(name)
             },
             launchOpenPicker = { openLauncher.launch(arrayOf("application/json")) },
-            onExportCompleted = onExportCompleted,
+            onExportCompleted = { isSuccess -> currentOnExportCompleted(isSuccess) },
             clearPending = { pendingJson = null },
         )
     }

--- a/shared/feature-rooms/ui/src/iosMain/kotlin/dev/nonoxy/residetrack/feature/rooms/ui/BackupFilePicker.ios.kt
+++ b/shared/feature-rooms/ui/src/iosMain/kotlin/dev/nonoxy/residetrack/feature/rooms/ui/BackupFilePicker.ios.kt
@@ -1,13 +1,16 @@
 package dev.nonoxy.residetrack.feature.rooms.ui
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.usePinned
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import platform.Foundation.NSData
@@ -22,6 +25,10 @@ import platform.Foundation.writeToURL
 import platform.UIKit.UIApplication
 import platform.UIKit.UIDocumentPickerDelegateProtocol
 import platform.UIKit.UIDocumentPickerViewController
+import platform.UIKit.UISceneActivationStateForegroundActive
+import platform.UIKit.UIViewController
+import platform.UIKit.UIWindow
+import platform.UIKit.UIWindowScene
 import platform.UniformTypeIdentifiers.UTTypeJSON
 import platform.darwin.NSObject
 
@@ -31,7 +38,16 @@ internal actual fun rememberBackupFilePicker(
     onExportCompleted: (Boolean) -> Unit,
 ): BackupFilePicker {
     val scope = rememberCoroutineScope()
-    return remember { IosBackupFilePicker(scope, onImported, onExportCompleted) }
+    val currentOnImported by rememberUpdatedState(onImported)
+    val currentOnExportCompleted by rememberUpdatedState(onExportCompleted)
+
+    return remember {
+        IosBackupFilePicker(
+            scope = scope,
+            onImported = { json -> currentOnImported(json) },
+            onExportCompleted = { isSuccess -> currentOnExportCompleted(isSuccess) },
+        )
+    }
 }
 
 @OptIn(ExperimentalForeignApi::class)
@@ -46,7 +62,7 @@ private class IosBackupFilePicker(
 
     override fun launchSave(json: String, suggestedName: String) {
         scope.launch {
-            val tempUrl = withContext(Dispatchers.Default) { writeTempFile(json, suggestedName) }
+            val tempUrl = withContext(Dispatchers.IO) { writeTempFile(json, suggestedName) }
             if (tempUrl == null) {
                 onExportCompleted(false)
                 return@launch
@@ -54,10 +70,10 @@ private class IosBackupFilePicker(
             // Resumed on the main dispatcher — UIKit presentation must stay on the main thread.
             val picker = UIDocumentPickerViewController(forExportingURLs = listOf(tempUrl))
             present(
-                picker,
+                picker = picker,
                 onPicked = { urls ->
                     scope.launch {
-                        val saved = withContext(Dispatchers.Default) {
+                        val saved = withContext(Dispatchers.IO) {
                             val exists = (urls.firstOrNull() as? NSURL)?.let(::destinationExists) ?: false
                             removeTempFile(tempUrl)
                             exists
@@ -66,7 +82,7 @@ private class IosBackupFilePicker(
                     }
                 },
                 onCancelled = {
-                    scope.launch { withContext(Dispatchers.Default) { removeTempFile(tempUrl) } }
+                    scope.launch { withContext(Dispatchers.IO) { removeTempFile(tempUrl) } }
                 },
             )
         }
@@ -79,7 +95,7 @@ private class IosBackupFilePicker(
             onPicked = { urls ->
                 val url = urls.firstOrNull() as? NSURL ?: return@present
                 scope.launch {
-                    val content = withContext(Dispatchers.Default) { readSecurityScoped(url) }
+                    val content = withContext(Dispatchers.IO) { readSecurityScoped(url) }
                     if (content != null) onImported(content)
                 }
             },
@@ -93,8 +109,10 @@ private class IosBackupFilePicker(
         val bytes = json.encodeToByteArray()
         if (bytes.isEmpty()) return null
         val written = bytes.usePinned { pinned ->
-            NSData.create(bytes = pinned.addressOf(0), length = bytes.size.toULong())
-                .writeToURL(url, atomically = true)
+            NSData.create(
+                bytes = pinned.addressOf(0),
+                length = bytes.size.toULong(),
+            ).writeToURL(url, atomically = true)
         }
         return if (written) url else null
     }
@@ -140,8 +158,31 @@ private class IosBackupFilePicker(
         )
         delegate = pickerDelegate
         picker.delegate = pickerDelegate
-        val root = UIApplication.sharedApplication.keyWindow?.rootViewController
-        root?.presentViewController(picker, animated = true, completion = null)
+        topmostViewController()?.presentViewController(
+            viewControllerToPresent = picker,
+            animated = true,
+            completion = null,
+        )
+    }
+
+    // Compose Multiplatform creates a separate UIWindow for Popup/DropdownMenu with a higher
+    // windowLevel, making it the keyWindow while a dropdown is visible. Presenting from that
+    // popup window silently fails, so we always pick the main app window (lowest windowLevel)
+    // and then traverse the presentedViewController chain.
+    private fun topmostViewController(): UIViewController? {
+        val scenes = UIApplication.sharedApplication.connectedScenes
+        val activeScene = scenes
+            .mapNotNull { scene -> scene as? UIWindowScene }
+            .firstOrNull { scene -> scene.activationState == UISceneActivationStateForegroundActive }
+            ?: scenes.firstNotNullOfOrNull { scene -> scene as? UIWindowScene }
+
+        val windows = activeScene?.windows?.mapNotNull { it as? UIWindow } ?: return null
+        val mainWindow = windows.minByOrNull { it.windowLevel }
+        var vc = mainWindow?.rootViewController
+        while (vc?.presentedViewController != null) {
+            vc = vc.presentedViewController
+        }
+        return vc
     }
 }
 

--- a/shared/main/build.gradle.kts
+++ b/shared/main/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     alias(libs.plugins.conventionPlugin.kmpLibrary)
     alias(libs.plugins.conventionPlugin.jsonSerialization)
     alias(libs.plugins.conventionPlugin.composeMultiplatformSetup)
+    alias(libs.plugins.moko.resources)
 }
 
 androidLibraryConfig {


### PR DESCRIPTION
## BackupFilePicker fixes

- **iOS modal not appearing**: Compose Multiplatform creates a separate `UIWindow` with higher `windowLevel` for `DropdownMenu`/`Popup`, making it the `keyWindow` while open. Presenting `UIDocumentPickerViewController` from that window fails silently. Fixed by always finding the main app window via `connectedScenes` + `minByOrNull { windowLevel }`.
- **Stale lambda capture**: `rememberBackupFilePicker` passed `onExportCompleted`/`onImported` directly into `remember {}` constructor — captured once at first composition. Fixed with `rememberUpdatedState` + lambda wrapper (`{ isSuccess -> currentOnExportCompleted(isSuccess) }`) on both platforms.
- **`Dispatchers.Default` → `Dispatchers.IO`** on iOS for all file operations (parity with Android).

## iOS project setup

- Rename Xcode project `iosApp` → `ResideTrack`
- Add `Dev.xcconfig` / `Prod.xcconfig` with flavor-specific `APP_NAME` and `BUNDLE_ID`; `Config.xcconfig` now holds only shared keys
- Replace `Debug`/`Release` build configs with `Dev Debug` / `Dev Release` / `Prod Debug` / `Prod Release`; wire `KOTLIN_FRAMEWORK_BUILD_TYPE` per config
- Add MOKO resources copy build phase to Xcode target; add `moko.resources` Gradle plugin to `:shared:main`
- Bump iOS deployment target `15.3` → `17.0`
- Add `[DEV] Reside Track` `app_name` override for Android dev flavor
- Switch `ContentView` `ignoresSafeArea` to `.all` (Compose owns all insets)