### PR TITLE
feat(ci): Android Release workflow + release signing

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -1,0 +1,69 @@
+name: Android Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      flavor:
+        description: Build flavor
+        type: choice
+        options:
+          - prod
+          - dev
+        default: prod
+      artifact_type:
+        description: Artifact type
+        type: choice
+        options:
+          - apk
+          - aab
+        default: apk
+
+jobs:
+  build-release:
+    name: Build ${{ inputs.flavor }} Release ${{ inputs.artifact_type }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - uses: gradle/actions/setup-gradle@v6
+
+      - name: Decode signing files
+        env:
+          SIGNING_PROPERTIES_BASE64: ${{ secrets.SIGNING_PROPERTIES_BASE64 }}
+          RELEASE_KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
+        run: |
+          echo "$SIGNING_PROPERTIES_BASE64" | base64 -d > signing.properties
+          echo "$RELEASE_KEYSTORE_BASE64" | base64 -d > keystores/release.keystore.jks
+
+      - name: Build Release APK
+        if: inputs.artifact_type == 'apk'
+        run: |
+          FLAVOR="${{ inputs.flavor }}"
+          ./gradlew :android:app:assemble${FLAVOR^}Release
+
+      - name: Build Release AAB
+        if: inputs.artifact_type == 'aab'
+        run: |
+          FLAVOR="${{ inputs.flavor }}"
+          ./gradlew :android:app:bundle${FLAVOR^}Release
+
+      - name: Upload APK
+        if: inputs.artifact_type == 'apk'
+        uses: actions/upload-artifact@v7
+        with:
+          name: app-${{ inputs.flavor }}-release-apk
+          path: android/app/build/outputs/apk/${{ inputs.flavor }}/release/*.apk
+          retention-days: 7
+
+      - name: Upload AAB
+        if: inputs.artifact_type == 'aab'
+        uses: actions/upload-artifact@v7
+        with:
+          name: app-${{ inputs.flavor }}-release-aab
+          path: android/app/build/outputs/bundle/${{ inputs.flavor }}Release/*.aab
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,9 @@ captures
 app_db.db
 .claude/scheduled_tasks.lock
 
+# Signing (never commit — upload as GitHub Secrets)
+signing.properties
+keystores/release.keystore.jks
+
 # AI tooling (local only)
 .superpowers/

--- a/.gitignore
+++ b/.gitignore
@@ -17,13 +17,6 @@ captures
 !*.xcworkspace/contents.xcworkspacedata
 **/xcshareddata/WorkspaceSettings.xcsettings
 
-# Local artifacts
-app_db.db
-.claude/scheduled_tasks.lock
-
 # Signing (never commit — upload as GitHub Secrets)
 signing.properties
 keystores/release.keystore.jks
-
-# AI tooling (local only)
-.superpowers/

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -2,6 +2,7 @@ import com.android.build.api.variant.impl.VariantOutputImpl
 import com.android.build.gradle.internal.tasks.FinalizeBundleTask
 import utils.AppVersion
 import java.util.Locale
+import java.util.Properties
 
 plugins {
     alias(libs.plugins.androidApplication)
@@ -44,21 +45,20 @@ android {
     }
 
     signingConfigs {
-        // TODO: Create release keystore and uncomment this
-        // register("release").configure {
-        //     file("$rootDir/signing.properties").let { file ->
-        //         if (!file.canRead()) error("signing.properties file read error")
-        //
-        //         val properties = Properties().apply {
-        //             file.inputStream().use { stream -> load(stream) }
-        //         }
-        //
-        //         storeFile = file("$rootDir/keystores/release.keystore.jks")
-        //         storePassword = properties.getProperty("keystorePassword")
-        //         keyAlias = properties.getProperty("keyAlias")
-        //         keyPassword = properties.getProperty("keyPassword")
-        //     }
-        // }
+        register("release").configure {
+            file("$rootDir/signing.properties").let { file ->
+                if (!file.canRead()) error("signing.properties file read error")
+
+                val properties = Properties().apply {
+                    file.inputStream().use { stream -> load(stream) }
+                }
+
+                storeFile = file("$rootDir/keystores/release.keystore.jks")
+                storePassword = properties.getProperty("keystorePassword")
+                keyAlias = properties.getProperty("keyAlias")
+                keyPassword = properties.getProperty("keyPassword")
+            }
+        }
 
         named("debug").configure {
             val DEBUG_STORE_PASSWORD: String by project
@@ -80,8 +80,7 @@ android {
         release {
             isMinifyEnabled = true
             isShrinkResources = true
-            // TODO: After create release signing config change "debug" -> "release"
-            signingConfig = signingConfigs.getByName("debug")
+            signingConfig = signingConfigs.getByName("release")
         }
     }
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -46,8 +46,8 @@ android {
 
     val signingPropertiesFile = rootProject.file("signing.properties")
     signingConfigs {
-        if (signingPropertiesFile.canRead()) {
-            register("release").configure {
+        register("release").configure {
+            if (signingPropertiesFile.canRead()) {
                 val properties = Properties().apply {
                     signingPropertiesFile.inputStream().use { stream -> load(stream) }
                 }
@@ -78,7 +78,7 @@ android {
         release {
             isMinifyEnabled = true
             isShrinkResources = true
-            signingConfig = signingConfigs.findByName("release")
+            signingConfig = signingConfigs.getByName("release")
         }
     }
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -44,15 +44,13 @@ android {
         }
     }
 
+    val signingPropertiesFile = rootProject.file("signing.properties")
     signingConfigs {
-        register("release").configure {
-            file("$rootDir/signing.properties").let { file ->
-                if (!file.canRead()) error("signing.properties file read error")
-
+        if (signingPropertiesFile.canRead()) {
+            register("release").configure {
                 val properties = Properties().apply {
-                    file.inputStream().use { stream -> load(stream) }
+                    signingPropertiesFile.inputStream().use { stream -> load(stream) }
                 }
-
                 storeFile = file("$rootDir/keystores/release.keystore.jks")
                 storePassword = properties.getProperty("keystorePassword")
                 keyAlias = properties.getProperty("keyAlias")
@@ -80,7 +78,7 @@ android {
         release {
             isMinifyEnabled = true
             isShrinkResources = true
-            signingConfig = signingConfigs.getByName("release")
+            signingConfig = signingConfigs.findByName("release")
         }
     }
 


### PR DESCRIPTION
## Summary

- Add `.github/workflows/android-release.yml` — manual `workflow_dispatch` trigger, selects flavor (dev/prod) and artifact type (apk/aab)
- Wire release `signingConfig` in `:android:app` — reads `signing.properties` + `keystores/release.keystore.jks` (both gitignored)
- Add signing files to `.gitignore`
- Secrets `SIGNING_PROPERTIES_BASE64` / `RELEASE_KEYSTORE_BASE64` already uploaded to repo

## How to trigger

GitHub → Actions → Android Release → Run workflow