### PR TITLE
fix(ci): fetch full git history for correct versionCode

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -24,6 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-java@v5
         with:


### PR DESCRIPTION
fetch-depth: 0 required — GitCommitCountValueSource uses git rev-list --count HEAD, shallow clone always returns 1.