### PR TITLE
fix(room-editor): three correctness bugs from code review

### DIFF
--- a/shared/feature-room-editor/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/impl/domain/RoomEditorExecutor.kt
+++ b/shared/feature-room-editor/impl/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/impl/domain/RoomEditorExecutor.kt
@@ -370,8 +370,15 @@ internal class RoomEditorExecutor(
             return
         }
 
-        val existingRooms = roomsRepository.getAllRooms().getOrElse { emptyList() }
+        dispatch(Message.SetIsLoading(isLoading = true))
+
+        val existingRooms = roomsRepository.getAllRooms().getOrElse {
+            dispatch(Message.SetIsLoading(isLoading = false))
+            publish(Label.ShowError(kind = RoomEditorErrorKind.FailedToUpdateRoom))
+            return
+        }
         if (RoomNumberConflict.exists(existingRooms, floor, number, excludeRoomId = room.id)) {
+            dispatch(Message.SetIsLoading(isLoading = false))
             dispatch(Message.SetRoomParams(params.copy(roomNumberError = true)))
             publish(Label.ShowError(kind = RoomEditorErrorKind.RoomNumberTaken))
             return
@@ -383,10 +390,12 @@ internal class RoomEditorExecutor(
             roomNumber = number,
             bedsCount = beds,
         ).onSuccess {
+            dispatch(Message.SetIsLoading(isLoading = false))
             dispatch(Message.SetRoom(room.copy(floorNumber = floor, roomNumber = number, bedsCount = beds)))
             dispatch(Message.SetShowRoomParams(show = false))
             publish(Label.ShowSuccess(kind = RoomEditorSuccessKind.RoomUpdated))
         }.onFailure {
+            dispatch(Message.SetIsLoading(isLoading = false))
             publish(Label.ShowError(kind = RoomEditorErrorKind.FailedToUpdateRoom))
         }
     }
@@ -394,6 +403,7 @@ internal class RoomEditorExecutor(
     private suspend fun handleDeleteRoom() {
         if (mode !is RoomEditorMode.ExistingRoom) return
         val room = state().room ?: return
+        dispatch(Message.SetIsLoading(isLoading = true))
         roomsRepository.deleteRoom(roomId = room.id)
             .onSuccess {
                 dispatch(Message.SetShowDeleteConfirm(show = false))
@@ -401,6 +411,7 @@ internal class RoomEditorExecutor(
                 publish(Label.NavigateBack)
             }
             .onFailure {
+                dispatch(Message.SetIsLoading(isLoading = false))
                 dispatch(Message.SetShowDeleteConfirm(show = false))
                 publish(Label.ShowError(kind = RoomEditorErrorKind.FailedToDeleteRoom))
             }

--- a/shared/feature-room-editor/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/presentation/mappers/UiRoomEditorStateMapper.kt
+++ b/shared/feature-room-editor/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/presentation/mappers/UiRoomEditorStateMapper.kt
@@ -22,6 +22,7 @@ internal class UiRoomEditorStateMapperImpl(
         isError = item.isError,
         errorKind = item.errorKind,
         room = item.room?.let(uiRoomMapper::map),
+        initialStudentCount = item.initialStudentCount,
         isSaveEnabled = item.isSaveEnabled,
         isAddStudentEnabled = item.isAddStudentEnabled,
         editableStudents = item.editableStudents.map { st ->

--- a/shared/feature-room-editor/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/presentation/models/UiRoomEditorState.kt
+++ b/shared/feature-room-editor/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/presentation/models/UiRoomEditorState.kt
@@ -10,6 +10,7 @@ data class UiRoomEditorState(
     val errorKind: RoomEditorErrorKind? = null,
     val room: UiRoom? = null,
     val editableStudents: ImmutableList<UiEditableStudent> = persistentListOf(),
+    val initialStudentCount: Int = 0,
     val isSaveEnabled: Boolean = false,
     val isAddStudentEnabled: Boolean = true,
     val isDirty: Boolean = false,

--- a/shared/feature-room-editor/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/ui/RoomEditorScreen.kt
+++ b/shared/feature-room-editor/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/ui/RoomEditorScreen.kt
@@ -56,6 +56,7 @@ internal fun RoomEditorScreen(
     if (state.showRoomParams && state.roomParams != null) {
         RoomParamsSheet(
             params = state.roomParams!!,
+            isLoading = state.isLoading,
             onFloorChange = viewModel::onRoomParamsFloorChange,
             onRoomNumberChange = viewModel::onRoomParamsRoomNumberChange,
             onBedsChange = viewModel::onRoomParamsBedsChange,
@@ -75,7 +76,8 @@ internal fun RoomEditorScreen(
     if (state.showDeleteConfirm) {
         DeleteRoomDialog(
             roomNumber = state.room?.roomNumber.orEmpty(),
-            studentCount = state.editableStudents.size,
+            studentCount = state.initialStudentCount,
+            isLoading = state.isLoading,
             onConfirm = viewModel::onDeleteRoomConfirm,
             onDismiss = viewModel::onDeleteRoomDismiss,
         )

--- a/shared/feature-room-editor/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/ui/views/DeleteRoomDialog.kt
+++ b/shared/feature-room-editor/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/ui/views/DeleteRoomDialog.kt
@@ -12,6 +12,7 @@ import dev.nonoxy.residetrack.res.MR
 internal fun DeleteRoomDialog(
     roomNumber: String,
     studentCount: Int,
+    isLoading: Boolean,
     onConfirm: () -> Unit,
     onDismiss: () -> Unit,
 ) {
@@ -27,7 +28,7 @@ internal fun DeleteRoomDialog(
             Text(text = stringResource(MR.strings.room_editor_delete_confirm_message, studentCount))
         },
         confirmButton = {
-            TextButton(onClick = onConfirm) {
+            TextButton(onClick = onConfirm, enabled = !isLoading) {
                 Text(
                     text = stringResource(MR.strings.delete),
                     color = ResideTrackTheme.colors.textError,

--- a/shared/feature-room-editor/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/ui/views/RoomParamsSheet.kt
+++ b/shared/feature-room-editor/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/ui/views/RoomParamsSheet.kt
@@ -28,6 +28,7 @@ import dev.nonoxy.residetrack.res.MR
 @Composable
 internal fun RoomParamsSheet(
     params: UiRoomParams,
+    isLoading: Boolean,
     onFloorChange: (String) -> Unit,
     onRoomNumberChange: (String) -> Unit,
     onBedsChange: (String) -> Unit,
@@ -88,7 +89,7 @@ internal fun RoomParamsSheet(
                     .padding(top = padding_size_12),
                 verticalArrangement = Arrangement.spacedBy(padding_size_4),
             ) {
-                ResideTrackButton(onClick = onSave, modifier = Modifier.fillMaxWidth()) {
+                ResideTrackButton(onClick = onSave, enabled = !isLoading, modifier = Modifier.fillMaxWidth()) {
                     Text(
                         text = stringResource(MR.strings.room_editor_save_params),
                         style = ResideTrackTheme.typography.paragraph,


### PR DESCRIPTION
## Changes

- **`getAllRooms` silent bypass** (`RoomEditorExecutor:375`): `getOrElse { emptyList() }` on repo failure let the duplicate room-number check pass with an empty list — a conflicting room number could be written to the DB without any error shown. Now returns early with `FailedToUpdateRoom`.

- **Concurrent double-submit** (`handleSaveRoomParams` / `handleDeleteRoom`): MVIKotlin `CoroutineExecutor` launches one coroutine per intent; rapid double-tap fired two concurrent DB writes. Fixed with `SetIsLoading(true)` at entry and `enabled = !isLoading` on the Save (`RoomParamsSheet`) and Confirm (`DeleteRoomDialog`) buttons.

- **Wrong student count in delete dialog** (`RoomEditorScreen:78`): dialog used `editableStudents.size` (dirty buffer including unsaved additions/removals) instead of the persisted DB count. Added `initialStudentCount` to `UiRoomEditorState` and its mapper; dialog now uses that value.