### PR TITLE
feat(ui): global SnackbarBus — eliminate save-screen blocking delay

### DIFF
--- a/shared/core-presentation/build.gradle.kts
+++ b/shared/core-presentation/build.gradle.kts
@@ -17,6 +17,7 @@ commonMainDependencies {
 
         libs.mvikotlin.core,
         libs.mvikotlin.coroutines,
+        libs.moko.resources.core,
     )
 
     apis(

--- a/shared/core-presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/core/presentation/snackbar/SnackbarBus.kt
+++ b/shared/core-presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/core/presentation/snackbar/SnackbarBus.kt
@@ -1,0 +1,14 @@
+package dev.nonoxy.residetrack.core.presentation.snackbar
+
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.receiveAsFlow
+
+class SnackbarBus {
+    private val channel = Channel<SnackbarEvent>(Channel.BUFFERED)
+    val events: Flow<SnackbarEvent> = channel.receiveAsFlow()
+
+    fun send(event: SnackbarEvent) {
+        channel.trySend(event)
+    }
+}

--- a/shared/core-presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/core/presentation/snackbar/SnackbarEvent.kt
+++ b/shared/core-presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/core/presentation/snackbar/SnackbarEvent.kt
@@ -1,0 +1,8 @@
+package dev.nonoxy.residetrack.core.presentation.snackbar
+
+import dev.icerock.moko.resources.StringResource
+
+data class SnackbarEvent(
+    val message: StringResource,
+    val type: SnackbarEventType,
+)

--- a/shared/core-presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/core/presentation/snackbar/SnackbarEventType.kt
+++ b/shared/core-presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/core/presentation/snackbar/SnackbarEventType.kt
@@ -1,0 +1,3 @@
+package dev.nonoxy.residetrack.core.presentation.snackbar
+
+enum class SnackbarEventType { SUCCESS, ERROR, INFO }

--- a/shared/feature-room-editor/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/presentation/RoomEditorViewModel.kt
+++ b/shared/feature-room-editor/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/presentation/RoomEditorViewModel.kt
@@ -1,28 +1,49 @@
 package dev.nonoxy.residetrack.feature.room_editor.presentation
 
+import androidx.lifecycle.viewModelScope
 import com.arkivanov.mvikotlin.extensions.coroutines.labels
 import com.arkivanov.mvikotlin.extensions.coroutines.states
+import dev.nonoxy.residetrack.core.presentation.snackbar.SnackbarBus
+import dev.nonoxy.residetrack.core.presentation.snackbar.SnackbarEvent
+import dev.nonoxy.residetrack.core.presentation.snackbar.SnackbarEventType
+import dev.nonoxy.residetrack.core.presentation.viewmodel.BaseViewModel
 import dev.nonoxy.residetrack.feature.room_editor.api.store.RoomEditorStore
 import dev.nonoxy.residetrack.feature.room_editor.api.store.RoomEditorStore.DateField
 import dev.nonoxy.residetrack.feature.room_editor.api.store.RoomEditorStore.Intent
+import dev.nonoxy.residetrack.feature.room_editor.api.store.RoomEditorSuccessKind
 import dev.nonoxy.residetrack.feature.room_editor.presentation.mappers.UiRoomEditorLabelMapper
 import dev.nonoxy.residetrack.feature.room_editor.presentation.mappers.UiRoomEditorStateMapper
 import dev.nonoxy.residetrack.feature.room_editor.presentation.models.UiDateField
 import dev.nonoxy.residetrack.feature.room_editor.presentation.models.UiRoomEditorLabel
 import dev.nonoxy.residetrack.feature.room_editor.presentation.models.UiRoomEditorState
-import dev.nonoxy.residetrack.core.presentation.viewmodel.BaseViewModel
+import dev.nonoxy.residetrack.res.MR
+import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.launch
 
 class RoomEditorViewModel internal constructor(
     private val store: RoomEditorStore,
     private val stateMapper: UiRoomEditorStateMapper,
     private val labelMapper: UiRoomEditorLabelMapper,
+    private val snackbarBus: SnackbarBus,
 ) : BaseViewModel<UiRoomEditorState, UiRoomEditorLabel>(initialState = UiRoomEditorState()) {
 
     init {
         bindAndStart {
             store.states.mapNotNull(stateMapper::map) bindTo ::acceptState
             store.labels.mapNotNull(labelMapper::map) bindTo ::acceptLabel
+        }
+        viewModelScope.launch {
+            store.labels
+                .filterIsInstance<RoomEditorStore.Label.ShowSuccess>()
+                .collect { label ->
+                    snackbarBus.send(
+                        SnackbarEvent(
+                            message = label.kind.toStringResource(),
+                            type = SnackbarEventType.SUCCESS,
+                        )
+                    )
+                }
         }
     }
 
@@ -85,5 +106,11 @@ class RoomEditorViewModel internal constructor(
     private fun UiDateField.toDomain(): DateField = when (this) {
         UiDateField.CHECK_IN -> DateField.CHECK_IN
         UiDateField.CHECK_OUT -> DateField.CHECK_OUT
+    }
+
+    private fun RoomEditorSuccessKind.toStringResource() = when (this) {
+        RoomEditorSuccessKind.StudentsSaved -> MR.strings.students_saved_successfully
+        RoomEditorSuccessKind.RoomUpdated -> MR.strings.room_updated_successfully
+        RoomEditorSuccessKind.RoomDeleted -> MR.strings.room_deleted_successfully
     }
 }

--- a/shared/feature-room-editor/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/presentation/di/FeatureRoomEditorPresentationModule.kt
+++ b/shared/feature-room-editor/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/presentation/di/FeatureRoomEditorPresentationModule.kt
@@ -26,6 +26,7 @@ val featureRoomEditorPresentationModule = module {
             store = get { parametersOf(mode) },
             stateMapper = get(),
             labelMapper = get(),
+            snackbarBus = get(),
         )
     }
 }

--- a/shared/feature-room-editor/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/presentation/mappers/UiRoomEditorLabelMapper.kt
+++ b/shared/feature-room-editor/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/presentation/mappers/UiRoomEditorLabelMapper.kt
@@ -3,22 +3,21 @@ package dev.nonoxy.residetrack.feature.room_editor.presentation.mappers
 import dev.nonoxy.residetrack.common.resources.StringConverter
 import dev.nonoxy.residetrack.feature.room_editor.api.store.RoomEditorErrorKind
 import dev.nonoxy.residetrack.feature.room_editor.api.store.RoomEditorStore
-import dev.nonoxy.residetrack.feature.room_editor.api.store.RoomEditorSuccessKind
 import dev.nonoxy.residetrack.feature.room_editor.presentation.models.UiRoomEditorLabel
 import dev.nonoxy.residetrack.res.MR
 
 internal interface UiRoomEditorLabelMapper {
-    fun map(item: RoomEditorStore.Label): UiRoomEditorLabel
+    fun map(item: RoomEditorStore.Label): UiRoomEditorLabel?
 }
 
 internal class UiRoomEditorLabelMapperImpl(
     private val stringConverter: StringConverter,
 ) : UiRoomEditorLabelMapper {
 
-    override fun map(item: RoomEditorStore.Label): UiRoomEditorLabel = when (item) {
+    override fun map(item: RoomEditorStore.Label): UiRoomEditorLabel? = when (item) {
         RoomEditorStore.Label.NavigateBack -> UiRoomEditorLabel.NavigateBack
         is RoomEditorStore.Label.ShowError -> UiRoomEditorLabel.ShowError(message = item.kind.toMessage())
-        is RoomEditorStore.Label.ShowSuccess -> UiRoomEditorLabel.ShowSuccess(message = item.kind.toMessage())
+        is RoomEditorStore.Label.ShowSuccess -> null
     }
 
     private fun RoomEditorErrorKind.toMessage(): String = when (this) {
@@ -40,11 +39,5 @@ internal class UiRoomEditorLabelMapperImpl(
         RoomEditorErrorKind.RoomNumberTaken -> stringConverter.convert(MR.strings.error_room_number_taken)
         RoomEditorErrorKind.FailedToUpdateRoom -> stringConverter.convert(MR.strings.error_failed_to_update_room)
         RoomEditorErrorKind.FailedToDeleteRoom -> stringConverter.convert(MR.strings.error_failed_to_delete_room)
-    }
-
-    private fun RoomEditorSuccessKind.toMessage(): String = when (this) {
-        RoomEditorSuccessKind.StudentsSaved -> stringConverter.convert(MR.strings.students_saved_successfully)
-        RoomEditorSuccessKind.RoomUpdated -> stringConverter.convert(MR.strings.room_updated_successfully)
-        RoomEditorSuccessKind.RoomDeleted -> stringConverter.convert(MR.strings.room_deleted_successfully)
     }
 }

--- a/shared/feature-room-editor/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/presentation/models/UiRoomEditorLabel.kt
+++ b/shared/feature-room-editor/presentation/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/presentation/models/UiRoomEditorLabel.kt
@@ -3,5 +3,4 @@ package dev.nonoxy.residetrack.feature.room_editor.presentation.models
 sealed interface UiRoomEditorLabel {
     data object NavigateBack : UiRoomEditorLabel
     data class ShowError(val message: String) : UiRoomEditorLabel
-    data class ShowSuccess(val message: String) : UiRoomEditorLabel
 }

--- a/shared/feature-room-editor/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/ui/RoomEditorScreen.kt
+++ b/shared/feature-room-editor/ui/src/commonMain/kotlin/dev/nonoxy/residetrack/feature/room_editor/ui/RoomEditorScreen.kt
@@ -40,7 +40,7 @@ internal fun RoomEditorScreen(
     val state by viewModel.state.collectAsStateWithLifecycle()
 
     val snackbarHostState = remember { SnackbarHostState() }
-    var currentSnackbarType by rememberSaveable { mutableStateOf(SnackbarType.INFO) }
+    var currentSnackbarType by rememberSaveable { mutableStateOf(SnackbarType.ERROR) }
 
     BackHandler(enabled = state.isDirty && !state.isLoading) {
         viewModel.onDismissRequested()
@@ -94,14 +94,6 @@ internal fun RoomEditorScreen(
                     withDismissAction = true,
                 )
             }
-            is UiRoomEditorLabel.ShowSuccess -> {
-                currentSnackbarType = SnackbarType.INFO
-                snackbarHostState.currentSnackbarData?.dismiss()
-                snackbarHostState.showSnackbar(
-                    message = label.message,
-                    withDismissAction = true,
-                )
-            }
         }
     }
 
@@ -123,8 +115,7 @@ internal fun RoomEditorScreen(
                 snackbar = { snackbarData ->
                     when (currentSnackbarType) {
                         SnackbarType.ERROR -> ResideTrackErrorSnackbar(snackbarData = snackbarData)
-                        SnackbarType.INFO -> ResideTrackSnackbar(snackbarData = snackbarData)
-                        else -> Unit
+                        else -> ResideTrackSnackbar(snackbarData = snackbarData)
                     }
                 },
             )

--- a/shared/main/src/commonMain/kotlin/dev/nonoxy/residetrack/di/MainModule.kt
+++ b/shared/main/src/commonMain/kotlin/dev/nonoxy/residetrack/di/MainModule.kt
@@ -1,9 +1,12 @@
 package dev.nonoxy.residetrack.di
 
+import dev.nonoxy.residetrack.core.presentation.snackbar.SnackbarBus
 import dev.nonoxy.residetrack.ui.tabcontainer.TabContainerViewModel
+import org.koin.core.module.dsl.singleOf
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
 
 val mainModule = module {
+    singleOf(::SnackbarBus)
     viewModelOf(::TabContainerViewModel)
 }

--- a/shared/main/src/commonMain/kotlin/dev/nonoxy/residetrack/ui/tabcontainer/TabContainerScreen.kt
+++ b/shared/main/src/commonMain/kotlin/dev/nonoxy/residetrack/ui/tabcontainer/TabContainerScreen.kt
@@ -7,10 +7,13 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.DateRange
 import androidx.compose.material.icons.filled.Home
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -22,11 +25,16 @@ import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import dev.icerock.moko.resources.compose.stringResource
+import dev.nonoxy.residetrack.common.ui.common.snackbar.ResideTrackErrorSnackbar
+import dev.nonoxy.residetrack.common.ui.common.snackbar.ResideTrackSnackbar
+import dev.nonoxy.residetrack.common.ui.common.snackbar.ResideTrackSuccessSnackbar
+import dev.nonoxy.residetrack.common.ui.common.utils.CollectFlow
 import dev.nonoxy.residetrack.common.ui.theme.padding_size_12
 import dev.nonoxy.residetrack.common.ui.theme.padding_size_16
 import dev.nonoxy.residetrack.core.navigation.bottombar.BottomBarItem
 import dev.nonoxy.residetrack.core.navigation.bottombar.FloatingBottomBar
 import dev.nonoxy.residetrack.core.navigation.bottombar.LocalFloatingBottomBarInset
+import dev.nonoxy.residetrack.core.presentation.snackbar.SnackbarEventType
 import dev.nonoxy.residetrack.feature.rooms.ui.api.RoomsRoute
 import dev.nonoxy.residetrack.feature.upcoming.ui.api.UpcomingRoute
 import dev.nonoxy.residetrack.navigation.TabContainerNavHost
@@ -46,6 +54,15 @@ internal fun TabContainerScreen(
     val innerNavController = rememberNavController()
     val backStackEntry by innerNavController.currentBackStackEntryAsState()
     val badgeCount by viewModel.upcomingCount.collectAsStateWithLifecycle()
+
+    val snackbarHostState = remember { SnackbarHostState() }
+    var currentSnackbarType by remember { mutableStateOf(SnackbarEventType.INFO) }
+
+    viewModel.snackbarEvents.CollectFlow { event ->
+        currentSnackbarType = event.type
+        snackbarHostState.currentSnackbarData?.dismiss()
+        snackbarHostState.showSnackbar(message = event.message, withDismissAction = true)
+    }
 
     val selectedKey = if (backStackEntry?.destination?.hasRoute(UpcomingRoute::class) == true) {
         UPCOMING_KEY
@@ -95,6 +112,19 @@ internal fun TabContainerScreen(
                 .onSizeChanged { barHeightPx = it.height }
                 .navigationBarsPadding()
                 .padding(horizontal = padding_size_16, vertical = padding_size_12),
+        )
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(bottom = barInset),
+            snackbar = { snackbarData ->
+                when (currentSnackbarType) {
+                    SnackbarEventType.SUCCESS -> ResideTrackSuccessSnackbar(snackbarData = snackbarData)
+                    SnackbarEventType.ERROR -> ResideTrackErrorSnackbar(snackbarData = snackbarData)
+                    SnackbarEventType.INFO -> ResideTrackSnackbar(snackbarData = snackbarData)
+                }
+            },
         )
     }
 }

--- a/shared/main/src/commonMain/kotlin/dev/nonoxy/residetrack/ui/tabcontainer/TabContainerViewModel.kt
+++ b/shared/main/src/commonMain/kotlin/dev/nonoxy/residetrack/ui/tabcontainer/TabContainerViewModel.kt
@@ -2,17 +2,25 @@ package dev.nonoxy.residetrack.ui.tabcontainer
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import dev.nonoxy.residetrack.common.resources.StringConverter
 import dev.nonoxy.residetrack.common.utils.currentLocalDate
+import dev.nonoxy.residetrack.core.presentation.snackbar.SnackbarBus
+import dev.nonoxy.residetrack.core.presentation.snackbar.SnackbarEventType
 import dev.nonoxy.residetrack.core.rooms.domain.repository.RoomsRepository
 import dev.nonoxy.residetrack.core.rooms.domain.upcoming.UpcomingCheckouts
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 
+internal data class SnackbarUiEvent(val message: String, val type: SnackbarEventType)
+
 class TabContainerViewModel internal constructor(
     roomsRepository: RoomsRepository,
+    snackbarBus: SnackbarBus,
+    private val stringConverter: StringConverter,
 ) : ViewModel() {
 
     val upcomingCount: StateFlow<Int> =
@@ -27,4 +35,7 @@ class TabContainerViewModel internal constructor(
             }
             .catch { emit(0) }
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), 0)
+
+    val snackbarEvents: Flow<SnackbarUiEvent> = snackbarBus.events
+        .map { event -> SnackbarUiEvent(stringConverter.convert(event.message), event.type) }
 }

--- a/shared/main/src/commonMain/kotlin/dev/nonoxy/residetrack/ui/tabcontainer/TabContainerViewModel.kt
+++ b/shared/main/src/commonMain/kotlin/dev/nonoxy/residetrack/ui/tabcontainer/TabContainerViewModel.kt
@@ -36,6 +36,6 @@ class TabContainerViewModel internal constructor(
             .catch { emit(0) }
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), 0)
 
-    val snackbarEvents: Flow<SnackbarUiEvent> = snackbarBus.events
+    internal val snackbarEvents: Flow<SnackbarUiEvent> = snackbarBus.events
         .map { event -> SnackbarUiEvent(stringConverter.convert(event.message), event.type) }
 }


### PR DESCRIPTION
## What

`showSnackbar()` is a suspending function. Previously it blocked the label stream in `RoomEditorScreen`, so `NavigateBack` (published right after `ShowSuccess`) had to wait for the snackbar to be dismissed — users saw a 4-second delay after pressing Save before the screen closed.

## How

Introduce `SnackbarBus` — a `Channel.BUFFERED`-backed event bus in `core-presentation`. Any feature can emit `SnackbarEvent(StringResource, SnackbarEventType)` without suspending. `TabContainerScreen` hosts the global `SnackbarHost` above `FloatingBottomBar`.

**Flow after this PR:**
1. Save succeeds → `RoomEditorViewModel` emits to `SnackbarBus` (non-blocking) via separate `viewModelScope` coroutine
2. `Label.NavigateBack` fires immediately → screen closes
3. `TabContainerScreen` shows the success snackbar on top of the Rooms screen

## Changes

- `core-presentation`: `SnackbarEvent(StringResource, SnackbarEventType)` + `SnackbarBus` (Channel); `moko-resources-core` dep added
- `MainModule`: `singleOf(::SnackbarBus)`
- `RoomEditorViewModel`: injects `SnackbarBus`; `Label.ShowSuccess` collected separately in `viewModelScope` → emits to bus
- `UiRoomEditorLabelMapper`: `ShowSuccess → null`; dead `RoomEditorSuccessKind.toMessage()` removed
- `UiRoomEditorLabel`: `ShowSuccess` variant removed
- `RoomEditorScreen`: `ShowSuccess` branch removed from label collector
- `TabContainerViewModel`: injects `SnackbarBus` + `StringConverter`; exposes `snackbarEvents: Flow<SnackbarUiEvent>`
- `TabContainerScreen`: collects events, routes to `ResideTrackSuccessSnackbar` / `ResideTrackErrorSnackbar` / `ResideTrackSnackbar`