### PR TITLE
fix(build-logic): enable Android host tests

### DIFF
--- a/build-logic/src/main/kotlin/plugins/KmpLibraryPlugin.kt
+++ b/build-logic/src/main/kotlin/plugins/KmpLibraryPlugin.kt
@@ -69,6 +69,10 @@ class KmpLibraryPlugin : Plugin<Project> {
             compilerOptions {
                 jvmTarget.set(JvmTarget.fromTarget(libs.versions.javaVersion.get()))
             }
+
+            withHostTestBuilder { }.configure {
+                isIncludeAndroidResources = true
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- Add `withHostTestBuilder {}` to `androidLibraryConfig` in `KmpLibraryPlugin`
- Enables `testAndroidHostTest` Gradle task across all KMP library modules
- `isIncludeAndroidResources = true` allows tests to access Android resources